### PR TITLE
Fixing linking issues when using C99

### DIFF
--- a/gunrock/gunrock.h
+++ b/gunrock/gunrock.h
@@ -108,8 +108,10 @@ struct GRSetup
  * @brief Initialization function for GRSetup.
  * \return Initialized configurations object.
  */
-#ifdef __clang__
+// Proper way to check for C99
+#if __STDC_VERSION__ >= 199901L
 // http://clang.llvm.org/compatibility.html#inline
+// Link mentions is an issue with C99, not a clang specific issue
 static
 #endif
 inline struct GRSetup InitSetup()


### PR DESCRIPTION
Fixes issues with gcc 5.x which use c99 as the default C standard.