### PR TITLE
Addresses issue #76, allows users to install metis or boost.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
   link_directories(${Boost_LIBRARY_DIRS})
 else()
-  message(WARNING "Boost was requested but support was not found")
+  message(WARNING "Boost was requested but support was not found, run /dependencies/install_boost.sh for installation.")
 endif ()
 
 find_package(OpenMP)
@@ -39,6 +39,9 @@ else()
 endif()
 
 find_package(Metis 5.0 REQUIRED)
+if ( NOT Metis_FOUND )
+   message(WARNING "METIS was requested but support was not found, run /dependencies/install_metis.sh for installation.")
+endif( NOT Metis_FOUND)
 
 # begin /* How can I pass git SHA1 to compiler as definition using cmake? */
 # http://stackoverflow.com/questions/1435953/how-can-i-pass-git-sha1-to-compiler-as-definition-using-cmake/4318642#4318642

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
   link_directories(${Boost_LIBRARY_DIRS})
 else()
-  message(WARNING "Boost was requested but support was not found, run /dependencies/install_boost.sh for installation.")
+  message(WARNING "Boost was requested but support was not found, run /dep/install_boost.sh for installation.")
 endif ()
 
 find_package(OpenMP)
@@ -40,7 +40,7 @@ endif()
 
 find_package(Metis 5.0 REQUIRED)
 if ( NOT Metis_FOUND )
-   message(WARNING "METIS was requested but support was not found, run /dependencies/install_metis.sh for installation.")
+   message(WARNING "METIS was requested but support was not found, run /dep/install_metis.sh for installation.")
 endif( NOT Metis_FOUND)
 
 # begin /* How can I pass git SHA1 to compiler as definition using cmake? */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(gunrock_VERSION_PATCH 0)
 add_definitions("-DGUNROCKVERSION=${gunrock_VERSION_MAJOR}.${gunrock_VERSION_MINOR}.${gunrock_VERSION_PATCH}")
 
 set(gunrock_REQUIRED_BOOST_VERSION 1.53)
+set(gunrock_REQUIRED_METIS_VERSION 5.0)
 
 cmake_minimum_required(VERSION 2.8)
 
@@ -38,10 +39,15 @@ else()
   message(WARNING "OpenMP was requested but support was not found")
 endif()
 
-find_package(Metis 5.0 REQUIRED)
-if ( NOT Metis_FOUND )
-   message(WARNING "METIS was requested but support was not found, run /dep/install_metis.sh for installation.")
-endif( NOT Metis_FOUND)
+FIND_LIBRARY(METIS_LIB NAMES metis)
+find_package(Metis ${gunrock_REQUIRED_METIS_VERSION} REQUIRED)
+SET(METIS_FOUND FALSE)
+IF (METIS_LIB)
+  SET(METIS_FOUND TRUE)
+  message(STATUS "Found Metis")
+ELSE (METIS_LIB)
+  message(WARNING "Metis was requested but support was not found, run /dep/install_metis.sh for installation.")
+ENDIF (METIS_LIB)
 
 # begin /* How can I pass git SHA1 to compiler as definition using cmake? */
 # http://stackoverflow.com/questions/1435953/how-can-i-pass-git-sha1-to-compiler-as-definition-using-cmake/4318642#4318642

--- a/dep/install_boost.sh
+++ b/dep/install_boost.sh
@@ -1,0 +1,8 @@
+wget http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.bz2
+tar -xjvf boost_1_54_0.tar.bz2
+cd boost_1_54_0
+sudo ./bootstrap.sh
+sudo ./b2 install --prefix=/usr/local
+cd ../
+sudo rm -rf boost_1_54_0
+sudo rm boost_1_54_0.tar.bz2

--- a/dep/install_metis.sh
+++ b/dep/install_metis.sh
@@ -1,0 +1,22 @@
+if [ -z "$1" ]
+  then
+    echo "error: usage: ./install_metis.sh 32 or 64"
+
+  else
+    wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz
+    gunzip metis-5.1.0.tar.gz
+    tar -xvf metis-5.1.0.tar
+    cd metis-5.1.0
+    if [ $1 == 64 ]; then
+      #64-bit metis installation
+      cd include
+      sed -i.bak 's/#define IDXTYPEWIDTH 32/#define IDXTYPEWIDTH 64/' ./metis.h
+      cd ../
+    fi
+    sudo make config
+    sudo make
+    sudo make install
+    cd ../
+    rm metis-5.1.0.tar
+    sudo rm -rf metis-5.1.0
+fi


### PR DESCRIPTION
CMakeLists.txt now gives a warning if metis was not found, and also directs the users to the `dep/` directory where shell scripts for installing metis or boost on non-ubuntu linux users can be found.