### PR TITLE
Replace getlogin() and handle null pointers (#113)

### DIFF
--- a/gunrock/util/sysinfo.h
+++ b/gunrock/util/sysinfo.h
@@ -18,7 +18,7 @@
 #include <sys/utsname.h>        /* for Cpuinfo */
 #include <cuda.h>               /* for Gpuinfo */
 #include <cuda_runtime_api.h>   /* for Gpuinfo */
-#include <unistd.h>             /* for Userinfo */
+#include <pwd.h>                /* for Userinfo */
 
 
 namespace gunrock {
@@ -107,9 +107,9 @@ public:
     {
         json_spirit::mObject info;
         const char * usernotfound = "Not Found";
-        if (getlogin())
+        if (getpwuid(getuid()))
         {
-            info["login"] = getlogin();
+            info["login"] = getpwuid(getuid())->pw_name;
         } else
         {
             info["login"] = usernotfound;

--- a/gunrock/util/sysinfo.h
+++ b/gunrock/util/sysinfo.h
@@ -106,7 +106,14 @@ public:
     json_spirit::mObject getUserinfo() const
     {
         json_spirit::mObject info;
-        info["login"] = getlogin();
+        const char * usernotfound = "Not Found";
+        if (getlogin())
+        {
+            info["login"] = getlogin();
+        } else
+        {
+            info["login"] = usernotfound;
+        }
         return info;
     }
 };


### PR DESCRIPTION
This resolves #113, by checking for null pointers.

`getlogin()` has also been replaced by `getpwuid(getuid())` as this seems to be the more reliable alternative. 

However I don't expect this will work on Windows (#107)