### PR TITLE
Added support to not use Metis partitioner. Metis is now optional for…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,10 @@ FIND_PACKAGE(Metis ${gunrock_REQUIRED_METIS_VERSION} REQUIRED)
 SET(METIS_FOUND FALSE)
 if (METIS_LIB)
   set(METIS_FOUND TRUE)
-  add_definitions( -DMETIS_FOUND=TRUE )
+  add_definitions( -DMETIS_FOUND=true )
   message(STATUS "Found Metis")
 else (METIS_LIB)
-  add_definitions( -DMETIS_FOUND=FALSE )
+  add_definitions( -DMETIS_FOUND=false )
   message(WARNING "Metis was requested but support was not found,
   run `sudo apt-get install metis` or `/dep/install_metis.sh` for installation.")
 endif (METIS_LIB)
@@ -325,4 +325,3 @@ set_tests_properties(SHARED_LIB_TEST_PAGERANK
 #    data/simple_example/bips98_606.mtx --src=largestdegree)
 #set_tests_properties(TestBFS
 #    PROPERTIES PASS_REGULAR_EXPRESSION "CORRECT")
-

--- a/gunrock/app/metisp/metis_partitioner.cuh
+++ b/gunrock/app/metisp/metis_partitioner.cuh
@@ -12,6 +12,14 @@
  * @brief linkage to metis partitioner
  */
 
+/* Temporary fix for using Makefiles
+ * in tests/primitive_name/
+ */
+#ifndef METIS_FOUND
+  #define METIS_FOUND false
+#endif
+/* METIS_FOUND default false */
+
 #pragma once
 
 #ifdef METIS_FOUND
@@ -147,8 +155,8 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
 
       } else
       {
-        const char * str = "Metis was not found during installation, therefore metis partitioner cannot be used.";
-        retval = util::GRError(cudaErrorUnknown, str, __FILE__, __LINE__);
+        const char * str = "Metis was not found during installation, therefore metis partitioner cannot be used [default=false].";
+        retval = util::GRError(cudaErrorUnknown, str, __FILE__, 19);
       } // METIS_FOUND
         return retval;
     }

--- a/gunrock/app/metisp/metis_partitioner.cuh
+++ b/gunrock/app/metisp/metis_partitioner.cuh
@@ -14,8 +14,12 @@
 
 #pragma once
 
-#include <metis.h>
+#ifdef METIS_FOUND
+  #include <metis.h>
+#endif
+
 #include <gunrock/app/partitioner_base.cuh>
+#include <gunrock/util/error_utils.cuh>
 
 namespace gunrock {
 namespace app {
@@ -28,7 +32,7 @@ template <
     bool     ENABLE_BACKWARD = false,
     bool     KEEP_ORDER      = false,
     bool     KEEP_NODE_NUM   = false>
-struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value, 
+struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
     ENABLE_BACKWARD, KEEP_ORDER, KEEP_NODE_NUM>
 {
     typedef Csr<VertexId,SizeT,Value> GraphT;
@@ -61,7 +65,7 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
         else {
             float sum=0;
             for (int gpu=0;gpu<num_gpus;gpu++) sum+=weitage[gpu];
-            for (int gpu=0;gpu<num_gpus;gpu++) this->weitage[gpu]=weitage[gpu]/sum; 
+            for (int gpu=0;gpu<num_gpus;gpu++) this->weitage[gpu]=weitage[gpu]/sum;
         }
         for (int gpu=0;gpu<num_gpus;gpu++) this->weitage[gpu+1]+=this->weitage[gpu];
     }
@@ -105,7 +109,9 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
         for (idx_t edge = 0; edge < edges; edge++)
             tcolumn_indices[edge] = this->graph->column_indices[edge];
 
-        //int Status = 
+      if(METIS_FOUND)
+      {
+        //int Status =
                 METIS_PartGraphKway(
                     &nodes,                      // nvtxs  : the number of vertices in the graph
                     &ncons,                      // ncon   : the number of balancing constraints
@@ -120,7 +126,7 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
                     NULL,                        // options: the options
                     &objval,                     // objval : the returned edge-cut or the total communication volume
                     tpartition_table);           // part   : the returned partition vector of the graph
-        
+
         for (SizeT i=0;i<nodes;i++) this->partition_tables[0][i]=tpartition_table[i];
         delete[] tpartition_table; tpartition_table = NULL;
         delete[] trow_offsets    ; trow_offsets     = NULL;
@@ -138,6 +144,12 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
         backward_offsets     = this->backward_offsets;
         backward_partitions  = this->backward_partitions;
         backward_convertions = this->backward_convertions;
+
+      } else
+      {
+        const char * str = "Metis was not found during installation, therefore metis partitioner cannot be used.";
+        retval = util::GRError(cudaErrorUnknown, str, __FILE__, __LINE__);
+      } // METIS_FOUND
         return retval;
     }
 };

--- a/tests/bfs/test_bfs.cu
+++ b/tests/bfs/test_bfs.cu
@@ -94,7 +94,7 @@ void Usage()
         "[--traversal-mode=<0|1>]  Set traversal strategy, 0 for Load-Balanced\n"
         "                          1 for Dynamic-Cooperative (Default: dynamic\n"
         "                          determine based on average degree).\n"
-        "[--partition_method=<random|biasrandom|clustered|metis>]\n"
+        "[--partition-method=<random|biasrandom|clustered|metis>]\n"
         "                          Choose partitioner (Default use random).\n"
         "[--quiet]                 No output (unless --json is specified).\n"
         "[--json]                  Output JSON-format statistics to STDOUT.\n"
@@ -135,7 +135,7 @@ void DisplaySolution(
 
     if (num_nodes > 40) { num_nodes = 40; }
 
-    printf("\nFirst %lld labels of the GPU result:\n", 
+    printf("\nFirst %lld labels of the GPU result:\n",
         (long long)num_nodes);
 
     printf("[");
@@ -378,10 +378,10 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
         }
         ReferenceBFS<VertexId, SizeT, Value,
             MARK_PREDECESSORS, ENABLE_IDEMPOTENCE>(
-            graph, 
+            graph,
             reference_check_label,
-            reference_check_preds, 
-            src, 
+            reference_check_preds,
+            src,
             quiet_mode);
         if (!quiet_mode)
         {
@@ -446,8 +446,8 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
             num_errors = 0;
             for (VertexId v=0; v<graph->nodes; v++)
             {
-                if (h_labels[v] == 
-                    (ENABLE_IDEMPOTENCE ? -1 : util::MaxValue<VertexId>() - 1)) 
+                if (h_labels[v] ==
+                    (ENABLE_IDEMPOTENCE ? -1 : util::MaxValue<VertexId>() - 1))
                     continue; // unvisited vertex
                 if (v == src && h_preds[v] == -1) continue; // source vertex
                 VertexId pred = h_preds[v];
@@ -461,12 +461,12 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
                 if (h_labels[v] != h_labels[pred] + 1)
                 {
                     //if (num_errors == 0)
-                        printf("INCORRECT: label[%d] (%d) != label[%d] (%d) + 1\n", 
+                        printf("INCORRECT: label[%d] (%d) != label[%d] (%d) + 1\n",
                             v, h_labels[v], pred, h_labels[pred]);
                     num_errors ++;
                     continue;
                 }
-                
+
                 bool v_found = false;
                 for (SizeT t = graph->row_offsets[pred]; t < graph->row_offsets[pred+1]; t++)
                 if (v == graph->column_indices[t])
@@ -508,7 +508,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
                     v_[gpu][problem->original_vertexes[gpu][v]] = v;
             }
         }
-        util::Track_Results(graph, num_gpus, (VertexId)1, h_labels, reference_check_label, 
+        util::Track_Results(graph, num_gpus, (VertexId)1, h_labels, reference_check_label,
             num_gpus > 1 ? problem->partition_tables[0] : NULL, v_);
         char file_name[512];
         sprintf(file_name, "./eval/error_dump/error_%lld_%d.txt", (long long)time(NULL), gpu_idx[0]);
@@ -617,7 +617,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     cpu_timer.Stop();
     info->info["postprocess_time"] = cpu_timer.ElapsedMillis();
 
-    if (h_preds         ) 
+    if (h_preds         )
     {
         if (info->info["output_filename"].get_str() != "")
         {
@@ -634,7 +634,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
                 else if (h_preds[v] != -2) // valid pred
                     fout<< v+1 << "," << h_preds[v]+1 << std::endl;
             }
-            
+
             fout.close();
             delete[] fout_buf; fout_buf = NULL;
             cpu_timer.Stop();
@@ -753,12 +753,12 @@ int main_Value(CommandLineArgs *args)
 // disabled to reduce compile time
 //    if (args -> CheckCmdLineFlag("64bit-Value"))
 //        return main_<VertexId, SizeT, long long>(args);
-//    else 
+//    else
         return main_<VertexId, SizeT, int      >(args);
 }
 
 template <
-    typename VertexId> 
+    typename VertexId>
 int main_SizeT(CommandLineArgs *args)
 {
 // disabled to reduce compile time
@@ -773,7 +773,7 @@ int main_VertexId(CommandLineArgs *args)
 // disabled, because oprtr::filter::KernelPolicy::SmemStorage is too large for 64bit VertexId
 //    if (args -> CheckCmdLineFlag("64bit-VertexId"))
 //        return main_SizeT<long long>(args);
-//    else 
+//    else
         return main_SizeT<int      >(args);
 }
 

--- a/tests/cc/test_cc.cu
+++ b/tests/cc/test_cc.cu
@@ -106,7 +106,7 @@ void Usage()
         "                          (graph-edges * <factor>). (Default: 1.0)\n"
         "[--v]                     Print verbose per iteration debug info.\n"
         "[--iteration-num=<num>]   Number of runs to perform the test.\n"
-        "[--partition_method=<random|biasrandom|clustered|metis>]\n"
+        "[--partition-method=<random|biasrandom|clustered|metis>]\n"
         "                          Choose partitioner (Default use random).\n"
         "[--quiet]                 No output (unless --json is specified).\n"
         "[--json]                  Output JSON-format statistics to STDOUT.\n"
@@ -284,7 +284,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     typedef CCEnactor < Problem>
             //INSTRUMENT,
             //DEBUG,
-            //SIZE_CHECK > 
+            //SIZE_CHECK >
             Enactor;
 
     // parse configurations from mObject info
@@ -301,8 +301,8 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     bool    quick_mode             = info->info["quick_mode"        ].get_bool ();
     bool    stream_from_host       = info->info["stream_from_host"  ].get_bool ();
     int     traversal_mode         = info->info["traversal_mode"    ].get_int  ();
-    bool    instrument             = info->info["instrument"        ].get_bool (); 
-    bool    debug                  = info->info["debug_mode"        ].get_bool (); 
+    bool    instrument             = info->info["instrument"        ].get_bool ();
+    bool    debug                  = info->info["debug_mode"        ].get_bool ();
     bool    size_check             = info->info["size_check"        ].get_bool ();
     int     iterations             = 1; //set to 1 for now. info->info["num_iteration"].get_int();
     CpuTimer cpu_timer;
@@ -593,7 +593,7 @@ int main_VertexId(CommandLineArgs *args)
     // disabled, because oprtr::filter::KernelPolicy::SmemStorage is too large for 64bit VertexId
     //if (args -> CheckCmdLineFlag("64bit-VertexId"))
     //    return main_SizeT<long long>(args);
-    //else 
+    //else
         return main_SizeT<int      >(args);
 }
 

--- a/tests/pr/test_pr.cu
+++ b/tests/pr/test_pr.cu
@@ -116,7 +116,7 @@ void Usage()
         "[--iteration-num=<num>]   Number of runs to perform the test.\n"
         "[--max-iter=<num>]        Max iteration for rank score distribution\n"
         "                          before one round of PageRank run end.\n"
-        "[--partition_method=<random|biasrandom|clustered|metis>]\n"
+        "[--partition-method=<random|biasrandom|clustered|metis>]\n"
         "                          Choose partitioner (Default use random).\n"
         "[--delta=<delta>]         Delta for PageRank (Default 0.85f).\n"
         "[--error=<error>]         Error threshold for PageRank (Default 0.01f).\n"
@@ -434,7 +434,7 @@ void ReferencePageRank_Normalized(
             //{
             //    iteration ++;
             //}
-        }    
+        }
     }
     cpu_timer.Stop();
     float elapsed = cpu_timer.ElapsedMillis();
@@ -451,7 +451,7 @@ void ReferencePageRank_Normalized(
         pr_list[i].page_rank = rank_current[i];
     }
 
-    std::stable_sort(pr_list, pr_list + nodes, 
+    std::stable_sort(pr_list, pr_list + nodes,
                      PRCompare<RankPair<SizeT, Value> >);
 
     #pragma omp parallel for
@@ -464,10 +464,10 @@ void ReferencePageRank_Normalized(
     free(pr_list     ); pr_list      = NULL;
     free(rank_current); rank_current = NULL;
     free(rank_next   ); rank_next    = NULL;
-    if (!quiet) 
+    if (!quiet)
     {
-        printf("CPU iteration : %lld\n", (long long)iteration); 
-        printf("CPU PageRank finished in %lf msec.\n", elapsed); 
+        printf("CPU iteration : %lld\n", (long long)iteration);
+        printf("CPU PageRank finished in %lf msec.\n", elapsed);
     }
 }
 
@@ -501,7 +501,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     typedef PREnactor <Problem>
             //INSTRUMENT,
             //DEBUG,
-            //SIZE_CHECK > 
+            //SIZE_CHECK >
             Enactor;
 
     // parse configurations from mObject info
@@ -663,7 +663,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
             if (v < 0 || v >= graph->nodes)
             {
                 if (error_count == 0 && !quiet_mode)
-                    printf("INCORRECT : node_id[%lld] (%lld) is out of bound\n", 
+                    printf("INCORRECT : node_id[%lld] (%lld) is out of bound\n",
                         (long long)i, (long long)v);
                 error_count ++;
                 continue;
@@ -671,7 +671,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
             if (v_count[v] > 0)
             {
                 if (error_count == 0 && !quiet_mode)
-                    printf("INCORRECT : node_id[%lld] (%lld) appears more than once\n", 
+                    printf("INCORRECT : node_id[%lld] (%lld) appears more than once\n",
                         (long long)i, (long long)v);
                 error_count ++;
                 continue;
@@ -724,11 +724,11 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
         else if (!quiet_mode)
             printf("number of errors : %lld\n", (long long) error_count);
         printf("Reference total rank : %.10lf\n", ref_total_rank);
-        printf("Maximum difference : "); 
+        printf("Maximum difference : ");
         if (max_diff_pos < graph->nodes)
             printf("rank[%lld] %.8le vs. %.8le, ",
-                (long long)ref_node_id[max_diff_pos], 
-                (double)unorder_rank[ref_node_id[max_diff_pos]], 
+                (long long)ref_node_id[max_diff_pos],
+                (double)unorder_rank[ref_node_id[max_diff_pos]],
                 (double)ref_rank[max_diff_pos]);
         printf("%.8le\n", (double)max_diff);
         printf("Maximum relative difference :");
@@ -746,7 +746,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
         {
             if (error_count == 0 && !quiet_mode)
                 printf("INCORRECT : rank[%lld] (%.8le), place %lld < rank[%lld] (%.8le), place %lld\n",
-                    (long long)h_node_id[i  ], (double)h_rank[i  ], (long long)i, 
+                    (long long)h_node_id[i  ], (double)h_rank[i  ], (long long)i,
                     (long long)h_node_id[i+1], (double)h_rank[i+1], (long long)i+1);
             error_count ++;
         }
@@ -827,8 +827,8 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     if (ref_node_id) { delete[] ref_node_id; ref_node_id = NULL; }
     cpu_timer.Stop();
     info->info["postprocess_time"] = cpu_timer.ElapsedMillis();
-    
-    if (h_rank     ) 
+
+    if (h_rank     )
     {
         if (info->info["output_filename"].get_str() !="")
         {
@@ -848,13 +848,13 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
             cpu_timer.Stop();
             info->info["write_time"] = cpu_timer.ElapsedMillis();
         }
-        delete[] h_rank     ; h_rank      = NULL; 
+        delete[] h_rank     ; h_rank      = NULL;
     }
     if (h_node_id  ) { delete[] h_node_id  ; h_node_id   = NULL; }
     cpu_timer.Stop();
     info->info["postprocess_time"] = cpu_timer.ElapsedMillis();
-    
-    if (h_rank     ) 
+
+    if (h_rank     )
     {
         if (info->info["output_filename"].get_str() !="")
         {
@@ -874,7 +874,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
             cpu_timer.Stop();
             info->info["write_time"] = cpu_timer.ElapsedMillis();
         }
-        delete[] h_rank     ; h_rank      = NULL; 
+        delete[] h_rank     ; h_rank      = NULL;
     }
 }
 
@@ -958,7 +958,7 @@ int main_Value(CommandLineArgs *args)
 // disabled to reduce compile time
 //    if (args -> CheckCmdLineFlag("64bit-Value"))
 //        return main_<VertexId, SizeT, double>(args);
-//    else 
+//    else
         return main_<VertexId, SizeT, float >(args);
 }
 
@@ -970,7 +970,7 @@ int main_SizeT(CommandLineArgs *args)
 // disabled to reduce compile time
 //    if (args -> CheckCmdLineFlag("64bit-SizeT"))
 //        return main_Value<VertexId, long long>(args);
-//    else 
+//    else
         return main_Value<VertexId, int      >(args);
 }
 
@@ -979,7 +979,7 @@ int main_VertexId(CommandLineArgs *args)
     // disabled, because oprtr::filter::KernelPolicy::SmemStorage is too large for 64bit VertexId
     //if (args -> CheckCmdLineFlag("64bit-VertexId"))
     //    return main_SizeT<long long>(args);
-    //else 
+    //else
         return main_SizeT<int      >(args);
 }
 
@@ -988,10 +988,10 @@ int main(int argc, char** argv)
     CommandLineArgs args(argc, argv);
     int graph_args = argc - args.ParsedArgc() - 1;
     if (argc < 2 || graph_args < 1 || args.CheckCmdLineFlag("help"))
-    {   
+    {
         Usage();
         return 1;
-    }   
+    }
 
     return main_VertexId(&args);
 }

--- a/tests/sssp/test_sssp.cu
+++ b/tests/sssp/test_sssp.cu
@@ -98,7 +98,7 @@ void Usage()
         "[--traversal-mode=<0|1>]  Set traversal strategy, 0 for Load-Balanced\n"
         "                          1 for Dynamic-Cooperative (Default: dynamic\n"
         "                          determine based on average degree).\n"
-        "[--partition_method=<random|biasrandom|clustered|metis>]\n"
+        "[--partition-method=<random|biasrandom|clustered|metis>]\n"
         "                          Choose partitioner (Default use random).\n"
         "[--delta_factor=<factor>] Delta factor for delta-stepping SSSP.\n"
         "[--quiet]                 No output (unless --json is specified).\n"
@@ -391,7 +391,7 @@ void RunTests(Info<VertexId, SizeT, Value> *info)
     for (int iter = 0; iter < iterations; ++iter)
     {
         util::GRError(problem->Reset(
-            src, enactor->GetFrontierType(), 
+            src, enactor->GetFrontierType(),
             max_queue_sizing, max_queue_sizing1),
             "SSSP Problem Data Reset Failed", __FILE__, __LINE__);
         util::GRError(enactor->Reset(),
@@ -597,7 +597,7 @@ int main_Value(CommandLineArgs *args)
 // Disabled becaus atomicMin(long long*, long long) is not available
 //    if (args -> CheckCmdLineFlag("64bit-Value"))
 //        return main_<VertexId, SizeT, long long>(args);
-//    else 
+//    else
         return main_<VertexId, SizeT, int      >(args);
 }
 
@@ -617,7 +617,7 @@ int main_VertexId(CommandLineArgs *args)
     // disabled, because oprtr::filter::KernelPolicy::SmemStorage is too large for 64bit VertexId
     //if (args -> CheckCmdLineFlag("64bit-VertexId"))
     //    return main_SizeT<long long>(args);
-    //else 
+    //else
         return main_SizeT<int      >(args);
 }
 


### PR DESCRIPTION
… gunrock. @sgpyc Can you please show me how to test, or test this yourself? I am not sure how to use `metis_partitioner.cuh` file to invoke the changes I have made. I tried `cmake` and compiling these changes and they work fine! It is suppose to print an error saying you cannot use metis partitioner if you do not have Metis installed. (Issue #97)