### PR TITLE
Improved CMakeLists.txt support for the entire project to...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,113 +5,51 @@ set(gunrock_VERSION_MINOR 3)
 set(gunrock_VERSION_PATCH 0)
 add_definitions("-DGUNROCKVERSION=${gunrock_VERSION_MAJOR}.${gunrock_VERSION_MINOR}.${gunrock_VERSION_PATCH}")
 
-set(gunrock_REQUIRED_CUDA_VERSION 7.5)
-set(gunrock_REQUIRED_BOOST_VERSION 1.56)
-set(gunrock_REQUIRED_METIS_VERSION 5.0)
-
 cmake_minimum_required(VERSION 2.8)
+
+# begin /* Suppress "deprecated auto_ptr" warnings caused by moderngpu */
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+add_definitions ("-Wno-deprecated-declarations")
+# end /* Suppress "deprecated auto_ptr" warnings caused by moderngpu */
 
 option(CMAKE_VERBOSE_MAKEFILE ON)
 
+# begin /* Find and set CUDA arch */
+set(gunrock_REQUIRED_CUDA_VERSION 7.5)
 FIND_PACKAGE(CUDA ${gunrock_REQUIRED_CUDA_VERSION} REQUIRED)
-
 if(CUDA_64_BIT_DEVICE_CODE)
   set(gunrock_arch_suffix x86_64)
 else()
   set(gunrock_arch_suffix i386)
 endif()
+# end /* Find and set CUDA arch */
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-
-FIND_PACKAGE(Boost ${gunrock_REQUIRED_BOOST_VERSION}
-  REQUIRED system filesystem timer chrono)
-if (Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-  link_directories(${Boost_LIBRARY_DIRS})
-else()
-  message(WARNING "Boost was requested but support was not found, run
-  `sudo apt-get install libboost1.58-all-dev` `/dep/install_boost.sh` for installation.")
-endif ()
-
-FIND_LIBRARY(METIS_LIB NAMES metis)
-FIND_PACKAGE(Metis ${gunrock_REQUIRED_METIS_VERSION} REQUIRED)
-SET(METIS_FOUND FALSE)
-if (METIS_LIB)
-  set(METIS_FOUND TRUE)
-  add_definitions( -DMETIS_FOUND=true )
-  message(STATUS "Found Metis")
-else (METIS_LIB)
-  add_definitions( -DMETIS_FOUND=false )
-  message(WARNING "Metis was requested but support was not found,
-  run `sudo apt-get install metis` or `/dep/install_metis.sh` for installation.")
-endif (METIS_LIB)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  # also see how to do overrides:
-  # https://gist.github.com/robertmaynard/11297565
-
-  # updated for CUDA 7, which uses libc++ rather than libstdc++
-  # older settings: check the git history
-  set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} 	 /opt/local/lib /opt/local/lib/libomp)
-  set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} 	 /opt/local/include /opt/local/include/libomp)
-
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-
-    #added for OpenMP on OS X using Macports
-    FIND_PATH(OPENMP_INCLUDE omp.h PATHS ${CMAKE_INCLUDE_PATH})
-    FIND_LIBRARY(OPENMP_LIB NAMES libgomp.dylib libomp.dylib libiomp5.dylib PATHS ${CMAKE_LIBRARY_PATH})
-    if (OPENMP_INCLUDE OR OPENMP_LIB)
-
-      link_directories("/opt/local/lib" "/opt/local/lib/libomp")
-      include_directories("/opt/local/include" "/opt/local/include/libomp")
-
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-      message(STATUS "Found OpenMP (-libomp)")
-    else()
-      message(WARNING "OpenMP (-libomp) was requested but support was not found")
-    endif(OPENMP_INCLUDE OR OPENMP_LIB)
-
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-
-else()
-
-  #added for OpenMP on Linux
-  FIND_PACKAGE(OpenMP)
-  if(OPENMP_FOUND)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    message(STATUS "Found OpenMP")
-  else()
-    message(WARNING "OpenMP was requested but support was not found")
-  endif()
-endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# begin /* Include Boost, OpenMP & Metis */
+include(${CMAKE_SOURCE_DIR}/cmake/FindBoostHeaders.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/FindBoost.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/FindOpenMP.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/FindMetis.cmake)
+# end /* Include Boost, OpenMP & Metis */
 
 # begin /* How can I pass git SHA1 to compiler as definition using cmake? */
 # http://stackoverflow.com/questions/1435953/how-can-i-pass-git-sha1-to-compiler-as-definition-using-cmake/4318642#4318642
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 # end /* How can I pass git SHA1 to compiler as definition using cmake? */
 
+# begin /* Include gunrock directories ./ */
 set(gunrock_INCLUDE_DIRS
   ${CMAKE_SOURCE_DIR})
 include_directories(${gunrock_INCLUDE_DIRS})
+# end /* Include gunrock directories ./ */
 
-set(mgpu_INCLUDE_DIRS
-  ${CMAKE_SOURCE_DIR}/externals/moderngpu/include
-  CACHE PATH
-  "Directory to the Modern GPU include files")
-
-set(mgpu_SOURCE_DIRS
-  ${CMAKE_SOURCE_DIR}/externals/moderngpu/src
-  CACHE PATH
-  "Directory to the Modern GPU source files")
-
-set(cub_INCLUDE_DIRS
-  ${CMAKE_SOURCE_DIR}/externals/cub
-  CACHE PATH
-  "Directory to the CUB include files")
+# begin /* Include moderngpu & cub */
+include(${CMAKE_SOURCE_DIR}/cmake/FindModernGPU.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/FindCUB.cmake)
+# end /* Include moderngpu & cub */
 
 ## Set the directory where the binaries will be stored
 set(EXECUTABLE_OUTPUT_PATH
@@ -125,6 +63,7 @@ set(LIBRARY_OUTPUT_PATH
   CACHE PATH
   "Directory where all the libraries will be stored")
 
+# begin /* SET GENCODE_SM */
 set(GENCODE_SM10
   -gencode=arch=compute_10,code=sm_10 -gencode=arch=compute_10,code=compute_10)
 set(GENCODE_SM13
@@ -139,9 +78,10 @@ set(GENCODE_SM37
   -gencode=arch=compute_37,code=sm_37 -gencode=arch=compute_37,code=compute_37)
 set(GENCODE_SM50
   -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_50,code=compute_50)
-
 #set(GENCODE -gencode=arch=compute_10,code=compute_10) # at least generate PTX
+# end /* SET GENCODE_SM */
 
+# begin /* Configure GUNROCK build options */
 option(GUNROCK_BUILD_LIB
   "On to build library"
   ON)
@@ -217,6 +157,7 @@ endif(GUNROCK_GENCODE_SM50)
 if (CUDA_VERBOSE_PTXAS)
   set(VERBOSE_PTXAS --ptxas-options=-v)
 endif (CUDA_VERBOSE_PTXAS)
+# end /* Configure GUNROCK build options */
 
 # c++11 is required
 set(CUDA_NVCC_FLAGS -std=c++11)
@@ -240,6 +181,7 @@ if(GUNROCK_BUILD_LIB)
   add_subdirectory(gunrock)
 endif(GUNROCK_BUILD_LIB)
 
+# begin /* Add premitives' subdirectories */
 if(GUNROCK_BUILD_APPLICATIONS)
   add_subdirectory(shared_lib_tests)
   #add_subdirectory(simple_example)
@@ -258,6 +200,7 @@ if(GUNROCK_BUILD_APPLICATIONS)
   #add_subdirectory(tests/vis)
   #add_subdirectory(tests/mis)
 endif(GUNROCK_BUILD_APPLICATIONS)
+# end /* Add premitives' subdirectories */
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,14 @@ add_definitions("-DGUNROCKVERSION=${gunrock_VERSION_MAJOR}.${gunrock_VERSION_MIN
 cmake_minimum_required(VERSION 2.8)
 
 # begin /* Suppress "deprecated auto_ptr" warnings caused by moderngpu */
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-add_definitions ("-Wno-deprecated-declarations")
+option(WARNING_DEP_FLAG "Deprecated declarations warning flag." OFF)
+if (WARNING_DEP_FLAG)
+  # moderngpu will give auto_ptr warning.
+else (WARNING_DEP_FLAG)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+  add_definitions ("-Wno-deprecated-declarations")
+endif (WARNING_DEP_FLAG)
 # end /* Suppress "deprecated auto_ptr" warnings caused by moderngpu */
 
 option(CMAKE_VERBOSE_MAKEFILE ON)
@@ -93,6 +98,54 @@ option(GUNROCK_BUILD_SHARED_LIBS
 option(GUNROCK_BUILD_APPLICATIONS
   "If on, builds the sample applications."
   ON)
+
+option(GUNROCK_APP_BC
+  "If on, builds only BC application."
+  OFF)
+
+option(GUNROCK_APP_BFS
+  "If on, builds only BFS application."
+  OFF)
+
+option(GUNROCK_APP_CC
+  "If on, builds only CC application."
+  OFF)
+
+option(GUNROCK_APP_PR
+  "If on, builds only PR application."
+  OFF)
+
+option(GUNROCK_APP_SSSP
+  "If on, builds only SSSP application."
+  OFF)
+
+option(GUNROCK_APP_DOBFS
+  "If on, builds only DOBFS application."
+  OFF)
+
+option(GUNROCK_APP_HITS
+  "If on, builds only HITS application."
+  OFF)
+
+option(GUNROCK_APP_SALSA
+  "If on, builds only SALSA application."
+  OFF)
+
+option(GUNROCK_APP_MST
+  "If on, builds only MST application."
+  OFF)
+
+option(GUNROCK_APP_WTF
+  "If on, builds only WTF application."
+  OFF)
+
+option(GUNROCK_APP_TOPK
+  "If on, builds only TOPK application."
+  OFF)
+
+#option(GUNROCK_APP_SAMPLE
+#  "If on, builds only SAMPLE application."
+#  OFF)
 
 option(GUNROCK_GENCODE_SM10
   "ON to generate code for Compute Capability 1.0 devices (e.g. Tesla C870)"
@@ -199,6 +252,57 @@ if(GUNROCK_BUILD_APPLICATIONS)
   #add_subdirectory(tests/template)
   #add_subdirectory(tests/vis)
   #add_subdirectory(tests/mis)
+
+# Individual options to build specific applications
+else(GUNROCK_BUILD_APPLICATIONS)
+  if(GUNROCK_APP_BC)
+    add_subdirectory(tests/bc)
+  endif(GUNROCK_APP_BC)
+
+  if(GUNROCK_APP_BFS)
+    add_subdirectory(tests/bfs)
+  endif(GUNROCK_APP_BFS)
+
+  if(GUNROCK_APP_CC)
+    add_subdirectory(tests/cc)
+  endif(GUNROCK_APP_CC)
+
+  if(GUNROCK_APP_PR)
+    add_subdirectory(tests/pr)
+  endif(GUNROCK_APP_PR)
+
+  if(GUNROCK_APP_SSSP)
+    add_subdirectory(tests/sssp)
+  endif(GUNROCK_APP_SSSP)
+
+  if(GUNROCK_APP_DOBFS)
+    add_subdirectory(tests/dobfs)
+  endif(GUNROCK_APP_DOBFS)
+
+  if(GUNROCK_APP_HITS)
+    add_subdirectory(tests/hits)
+  endif(GUNROCK_APP_HITS)
+
+  if(GUNROCK_APP_SALSA)
+    add_subdirectory(tests/salsa)
+  endif(GUNROCK_APP_SALSA)
+
+  if(GUNROCK_APP_MST)
+    add_subdirectory(tests/mst)
+  endif(GUNROCK_APP_MST)
+
+  if(GUNROCK_APP_WTF)
+    add_subdirectory(tests/wtf)
+  endif(GUNROCK_APP_WTF)
+
+  if(GUNROCK_APP_TOPK)
+    add_subdirectory(tests/topk)
+  endif(GUNROCK_APP_TOPK)
+
+  # if(GUNROCK_APP_SAMPLE)
+  #   add_subdirectory(tests/sample)
+  # endif(GUNROCK_APP_SAMPLE)
+
 endif(GUNROCK_BUILD_APPLICATIONS)
 # end /* Add premitives' subdirectories */
 

--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------
+#  Gunrock: Finds Boost package and includes/links directories
+# ------------------------------------------------------------------------
+SET(gunrock_REQUIRED_BOOST_VERSION 1.56)
+
+FIND_PACKAGE(Boost ${gunrock_REQUIRED_BOOST_VERSION}
+  REQUIRED system filesystem timer chrono)
+IF (Boost_FOUND)
+  INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
+  LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
+ELSE ()
+  MESSAGE(WARNING "Boost was requested but support was not found, run
+  `sudo apt-get install libboost1.58-all-dev` `/dep/install_boost.sh` for installation.")
+ENDIF ()

--- a/cmake/FindCUB.cmake
+++ b/cmake/FindCUB.cmake
@@ -1,0 +1,7 @@
+# ------------------------------------------------------------------------
+#  Gunrock: Find external cub directories
+# ------------------------------------------------------------------------
+SET(cub_INCLUDE_DIRS
+  ${CMAKE_SOURCE_DIR}/externals/cub
+  CACHE PATH
+  "Directory to the CUB include files")

--- a/cmake/FindMetis.cmake
+++ b/cmake/FindMetis.cmake
@@ -20,14 +20,30 @@ FIND_LIBRARY(PARMETIS_LIBRARY parmetis
   /usr/lib
   )
 
-FIND_LIBRARY(METIS_LIBRARY metis
-  /usr/local/lib
-  /usr/lib
-  )
-
 IF(PARMETIS_INCLUDE_DIR)
   IF(PARMETIS_LIBRARY)
     SET( PARMETIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARY})
     SET( PARMETIS_FOUND "YES" )
   ENDIF(PARMETIS_LIBRARY)
 ENDIF(PARMETIS_INCLUDE_DIR)
+
+# ------------------------------------------------------------------------
+#  Gunrock: Find Metis and set pre-compiler flag
+# ------------------------------------------------------------------------
+FIND_LIBRARY(METIS_LIBRARY metis
+  /usr/local/lib
+  /usr/lib
+  )
+
+SET(gunrock_REQUIRED_METIS_VERSION 5.0)
+
+SET(METIS_FOUND FALSE)
+IF (METIS_LIBRARY)
+  SET(METIS_FOUND TRUE)
+  ADD_DEFINITIONS( -DMETIS_FOUND=true )
+  MESSAGE(STATUS "Found Metis")
+ELSE (METIS_LIBRARY)
+  ADD_DEFINITIONS( -DMETIS_FOUND=false )
+  MESSAGE(WARNING "Metis was requested but support was not found,
+  run `sudo apt-get install metis` or `/dep/install_metis.sh` for installation.")
+ENDIF (METIS_LIBRARY)

--- a/cmake/FindModernGPU.cmake
+++ b/cmake/FindModernGPU.cmake
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------
+#  Gunrock: Find external moderngpu directories
+# ------------------------------------------------------------------------
+SET(mgpu_INCLUDE_DIRS
+  ${CMAKE_SOURCE_DIR}/externals/moderngpu/include
+  CACHE PATH
+  "Directory to the Modern GPU include files")
+
+SET(mgpu_SOURCE_DIRS
+  ${CMAKE_SOURCE_DIR}/externals/moderngpu/src
+  CACHE PATH
+  "Directory to the Modern GPU source files")

--- a/cmake/FindOpenMP.cmake
+++ b/cmake/FindOpenMP.cmake
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------------------
+#  Gunrock: Find OpenMP includes and libraries
+# ------------------------------------------------------------------------
+
+IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # also see how to do overrides:
+  # https://gist.github.com/robertmaynard/11297565
+
+  # updated for CUDA 7, which uses libc++ rather than libstdc++
+  # older settings: check the git history
+  SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} 	 /opt/local/lib /opt/local/lib/libomp)
+  SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} 	 /opt/local/include /opt/local/include/libomp)
+
+  IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+    #added for OpenMP on OS X using Macports
+    FIND_PATH(OPENMP_INCLUDE omp.h PATHS ${CMAKE_INCLUDE_PATH})
+    FIND_LIBRARY(OPENMP_LIB NAMES libgomp.dylib libomp.dylib libiomp5.dylib PATHS ${CMAKE_LIBRARY_PATH})
+    IF (OPENMP_INCLUDE OR OPENMP_LIB)
+
+      link_directories("/opt/local/lib" "/opt/local/lib/libomp")
+      include_directories("/opt/local/include" "/opt/local/include/libomp")
+
+      SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+      MESSAGE(STATUS "Found OpenMP (-libomp)")
+    ELSE()
+      MESSAGE(WARNING "OpenMP (-libomp) was requested but support was not found")
+    ENDIF(OPENMP_INCLUDE OR OPENMP_LIB)
+
+  ENDIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+ELSE()
+
+  #added for OpenMP on Linux
+  FIND_PACKAGE(OpenMP)
+  IF(OPENMP_FOUND)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    MESSAGE(STATUS "Found OpenMP")
+  ELSE()
+    MESSAGE(WARNING "OpenMP was requested but support was not found")
+  ENDIF()
+ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake/SetSubProject.cmake
+++ b/cmake/SetSubProject.cmake
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------
+#  Gunrock: Set sub projects includes, links and executables.
+# ------------------------------------------------------------------------
+
+# begin /* moderngpu include directories */
+if(mgpu_INCLUDE_DIRS)
+  include_directories(${mgpu_INCLUDE_DIRS})
+else()
+  message(SEND_ERROR "Modern GPU include directory not set.")
+endif()
+
+set (mgpu_SOURCE_FILES
+  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
+  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
+# end /* moderngpu include directories */
+
+# begin /* CUB include directories */
+if (cub_INCLUDE_DIRS)
+  include_directories(${cub_INCLUDE_DIRS})
+else()
+  message(SEND_ERROR "CUB include directory not set.")
+endif()
+# end /* CUB include directories */
+
+# begin /* Add CUDA executables */
+CUDA_ADD_EXECUTABLE(${PROJECT_NAME}
+  test_${PROJECT_NAME}.cu
+  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
+  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
+  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
+  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
+  ${mgpu_SOURCE_FILES}
+  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
+# end /* Add CUDA executables */
+
+# begin /* Link Metis and Boost */
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${METIS_LIBRARY})
+# end /* Link Metis and Boost */
+
+# begin /* Link OpenMP (libomp) for OSX */
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    link_directories("/opt/local/lib")
+    target_link_libraries(${PROJECT_NAME} "omp")
+  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# end /* Link OpenMP (libomp) for OSX */

--- a/gunrock/app/metisp/metis_partitioner.cuh
+++ b/gunrock/app/metisp/metis_partitioner.cuh
@@ -12,14 +12,6 @@
  * @brief linkage to metis partitioner
  */
 
-/* Temporary fix for using Makefiles
- * in tests/primitive_name/
- */
-#ifndef METIS_FOUND
-  #define METIS_FOUND false
-#endif
-/* METIS_FOUND default false */
-
 #pragma once
 
 #ifdef METIS_FOUND
@@ -155,8 +147,8 @@ struct MetisPartitioner : PartitionerBase<VertexId,SizeT,Value,
 
       } else
       {
-        const char * str = "Metis was not found during installation, therefore metis partitioner cannot be used [default=false].";
-        retval = util::GRError(cudaErrorUnknown, str, __FILE__, 19);
+        const char * str = "Metis was not found during installation, therefore metis partitioner cannot be used.";
+        retval = util::GRError(cudaErrorUnknown, str, __FILE__, __LINE__);
       } // METIS_FOUND
         return retval;
     }

--- a/tests/bc/CMakeLists.txt
+++ b/tests/bc/CMakeLists.txt
@@ -1,33 +1,6 @@
-# CMake file for BC test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(betweenness_centrality
-  test_bc.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(betweenness_centrality ${Boost_LIBRARIES})
-target_link_libraries(betweenness_centrality ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(betweenness_centrality "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Betweenness Centrality
+# ------------------------------------------------------------------------
+project(bc)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/bfs/CMakeLists.txt
+++ b/tests/bfs/CMakeLists.txt
@@ -1,8 +1,7 @@
 # CMake file for BFS test
 
 # set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-find_package(CUDA REQUIRED)
+# find_package(CUDA REQUIRED)
 
 if(mgpu_INCLUDE_DIRS)
   include_directories(${mgpu_INCLUDE_DIRS})

--- a/tests/bfs/CMakeLists.txt
+++ b/tests/bfs/CMakeLists.txt
@@ -1,34 +1,6 @@
-# CMake file for BFS test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-# find_package(CUDA REQUIRED)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(breadth_first_search
-  test_bfs.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(breadth_first_search ${Boost_LIBRARIES})
-target_link_libraries(breadth_first_search ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(breadth_first_search "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Breadth First Search
+# ------------------------------------------------------------------------
+project(bfs)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -1,33 +1,6 @@
-# CMake file for CC test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(connected_component
-  test_cc.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(connected_component ${Boost_LIBRARIES})
-target_link_libraries(connected_component ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(connected_component "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Connected Component
+# ------------------------------------------------------------------------
+project(cc)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/dobfs/CMakeLists.txt
+++ b/tests/dobfs/CMakeLists.txt
@@ -1,39 +1,6 @@
-# CMake file for Direction-Optimizing BFS test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-if (cub_INCLUDE_DIRS)
-  include_directories(${cub_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "CUB include directory not set.")
-endif()
-
-CUDA_ADD_EXECUTABLE(direction_optimizing_bfs
-  test_dobfs.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(direction_optimizing_bfs ${Boost_LIBRARIES})
-target_link_libraries(direction_optimizing_bfs ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(direction_optimizing_bfs "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Direction-Optimizing BFS
+# ------------------------------------------------------------------------
+project(dobfs)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/hits/CMakeLists.txt
+++ b/tests/hits/CMakeLists.txt
@@ -1,33 +1,6 @@
-# CMake file for HITS test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(HITS
-  test_hits.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(HITS ${Boost_LIBRARIES})
-target_link_libraries(HITS ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(HITS "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project HITS
+# ------------------------------------------------------------------------
+project(hits)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/mst/CMakeLists.txt
+++ b/tests/mst/CMakeLists.txt
@@ -1,39 +1,6 @@
-# CMake file for MST test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-if (cub_INCLUDE_DIRS)
-  include_directories(${cub_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "CUB include directory not set.")
-endif()
-
-CUDA_ADD_EXECUTABLE(minimum_spanning_tree
-  test_mst.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(minimum_spanning_tree ${Boost_LIBRARIES})
-target_link_libraries(minimum_spanning_tree ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(minimum_spanning_tree "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Minimum Spanning Tree
+# ------------------------------------------------------------------------
+project(mst)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/pr/CMakeLists.txt
+++ b/tests/pr/CMakeLists.txt
@@ -1,39 +1,6 @@
-# CMake file for PageRank test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if (mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-if (cub_INCLUDE_DIRS)
-  include_directories(${cub_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "CUB include directory not set.")
-endif()
-
-CUDA_ADD_EXECUTABLE(pagerank
-  test_pr.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(pagerank ${Boost_LIBRARIES})
-target_link_libraries(pagerank ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(pagerank "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project PageRank
+# ------------------------------------------------------------------------
+project(pr)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/salsa/CMakeLists.txt
+++ b/tests/salsa/CMakeLists.txt
@@ -1,32 +1,6 @@
-# CMake file for Stochastic Approach for Link-Structure Analysis test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set(mgpu_SOURCE_FILES ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(SALSA
-  test_salsa.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(SALSA ${Boost_LIBRARIES})
-target_link_libraries(SALSA ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(SALSA "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Stochastic Approach for Link-Structure Analysis
+# ------------------------------------------------------------------------
+project(salsa)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/sssp/CMakeLists.txt
+++ b/tests/sssp/CMakeLists.txt
@@ -1,33 +1,6 @@
-# CMake file for SSSP test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(single_source_shortest_path
-  test_sssp.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(single_source_shortest_path ${Boost_LIBRARIES})
-target_link_libraries(single_source_shortest_path ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(single_source_shortest_path "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Single Source Shortest Path
+# ------------------------------------------------------------------------
+project(sssp)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/template/CMakeLists.txt
+++ b/tests/template/CMakeLists.txt
@@ -1,33 +1,6 @@
-# CMake file for "template" (replace "template" with your executable)
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-CUDA_ADD_EXECUTABLE(template
-  test_sample.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(template ${Boost_LIBRARIES})
-target_link_libraries(template ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(template "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project "sample" (replace "sample" with your executable)
+# ------------------------------------------------------------------------
+project(sample)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/topk/CMakeLists.txt
+++ b/tests/topk/CMakeLists.txt
@@ -1,39 +1,6 @@
-# CMake file for degree centrality test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-if (cub_INCLUDE_DIRS)
-  include_directories(${cub_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "CUB include directory not set.")
-endif()
-
-CUDA_ADD_EXECUTABLE(degree_centrality
-  test_topk.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(degree_centrality ${Boost_LIBRARIES})
-target_link_libraries(degree_centrality ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(degree_centrality "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Degree Centrality
+# ------------------------------------------------------------------------
+project(topk)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)

--- a/tests/wtf/CMakeLists.txt
+++ b/tests/wtf/CMakeLists.txt
@@ -1,39 +1,6 @@
-# CMake file for WTF test
-
-# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -g;-G)
-
-if(mgpu_INCLUDE_DIRS)
-  include_directories(${mgpu_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "Modern GPU include directory not set.")
-endif()
-
-set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
-
-if (cub_INCLUDE_DIRS)
-  include_directories(${cub_INCLUDE_DIRS})
-else()
-  message(SEND_ERROR "CUB include directory not set.")
-endif()
-
-CUDA_ADD_EXECUTABLE(who_to_follow
-  test_wtf.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/test_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/error_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/misc_utils.cu
-  ${CMAKE_SOURCE_DIR}/gunrock/util/gitsha1.c
-  ${mgpu_SOURCE_FILES}
-  OPTIONS ${GENCODE} ${VERBOSE_PTXAS})
-
-target_link_libraries(who_to_follow ${Boost_LIBRARIES})
-target_link_libraries(who_to_follow ${METIS_LIBRARY})
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(who_to_follow "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# ------------------------------------------------------------------------
+#  Gunrock: Sub-Project Who To Follow
+# ------------------------------------------------------------------------
+project(wtf)
+message("-- Project Added: ${PROJECT_NAME}")
+include(${CMAKE_SOURCE_DIR}/cmake/SetSubProject.cmake)


### PR DESCRIPTION
include the following changes;
- Separated Metis, Boost, OpenMP, mGPU and CUB into their individual `.cmake` files, now we can just include them wherever we need them. In the root `CMakeLists.txt` they are all included.
- Commented a lot of code in `CMakeLists.txt` to basically explain the important sections if further edits are required in future, I have cleaned up a lot of stuff in there.
- Added the following code to suppress the warnings due to `auto_ptr` in moderngpu:
```
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
add_definitions ("-Wno-deprecated-declarations")
``` 
- Commented `find_package(CUDA REQUIRED)` in `bfs/CMakeLists.txt` because it is redundant and causes extra message echo in the root cmake compilation.

Everything was tested and worked beautifully, without any annoying warnings from moderngpu. :) This pull request addresses part of issue #139. Later part of compiling sub-projects I am still working on, but that is a different pull request.