### PR TITLE
Minor updates to all the scripts in order to pass EXEDIR and DATADIR

### DIFF
--- a/dataset/test-scripts/topc/README.md
+++ b/dataset/test-scripts/topc/README.md
@@ -1,0 +1,11 @@
+TOPC benchmarking scripts
+=========================
+Make sure you have downloaded the required datasets by:
+```cd <gunrockRoot>/dataset/large && make TOPC```
+In case you see errors from wget complaining about certificates, use the following command instead:
+```cd <gunrockRoot>/dataset/large && make WGET="wget --no-check-certificate" TOPC```
+
+Running the benchmarks after that is as simple as:
+```cd <gunrockRoot>/dataset/test-scripts/topc && ./topc-test.sh <EXEDIR> <DATADIR>```
+If you have followed the default build commands, the above commandwill be:
+```cd <gunrockRoot>/dataset/test-scripts/topc && ./topc-test.sh ../../../build/bin/ ../../large/```

--- a/dataset/test-scripts/topc/bc-test.sh
+++ b/dataset/test-scripts/topc/bc-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-EXEDIR="../../../../gunrock_build/bin"
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
 EXECUTION="bc"
-#DATADIR="../../large"
-DATADIR="/data/gunrock_dataset/large"
 SETTING=" --src=0 --iteration-num=10"
 NAME[0]="soc-LiveJournal1" && DO_A[0]="0.200"   && DO_B[0]="0.1" && T_MODE[0]="LB_CULL"
 NAME[1]="soc-orkut"        && DO_A[1]="0.012"   && DO_B[1]="0.1" && T_MODE[1]="LB_CULL"

--- a/dataset/test-scripts/topc/bfs-test.sh
+++ b/dataset/test-scripts/topc/bfs-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-EXEDIR="../../../../gunrock_build/bin"
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
 EXECUTION="bfs"
-#DATADIR="../../large"
-DATADIR="/data/gunrock_dataset/large"
 SETTING=" --src=0 --undirected --idempotence --queue-sizing=6.5 --in-sizing=4 --iteration-num=10 --direction-optimized"
 NAME[0]="soc-LiveJournal1" && DO_A[0]="0.200"   && DO_B[0]="0.1" && T_MODE[0]="LB_CULL"
 NAME[1]="soc-orkut"        && DO_A[1]="0.012"   && DO_B[1]="0.1" && T_MODE[1]="LB_CULL"

--- a/dataset/test-scripts/topc/cc-test.sh
+++ b/dataset/test-scripts/topc/cc-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-EXEDIR="../../../../gunrock_build/bin"
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
 EXECUTION="cc"
-#DATADIR="../../large"
-DATADIR="/data/gunrock_dataset/large"
 SETTING=" --iteration-num=10"
 NAME[0]="soc-LiveJournal1" && DO_A[0]="0.200"   && DO_B[0]="0.1" && T_MODE[0]="LB_CULL"
 NAME[1]="soc-orkut"        && DO_A[1]="0.012"   && DO_B[1]="0.1" && T_MODE[1]="LB_CULL"

--- a/dataset/test-scripts/topc/pr-test.sh
+++ b/dataset/test-scripts/topc/pr-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-EXEDIR="../../../../gunrock_build/bin"
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
 EXECUTION="pr"
-#DATADIR="../../large"
-DATADIR="/data/gunrock_dataset/large"
 SETTING=" --quick --iteration-num=10 --max-iter=1"
 NAME[0]="soc-LiveJournal1" && DO_A[0]="0.200"   && DO_B[0]="0.1" && T_MODE[0]="LB_CULL"
 NAME[1]="soc-orkut"        && DO_A[1]="0.012"   && DO_B[1]="0.1" && T_MODE[1]="LB_CULL"

--- a/dataset/test-scripts/topc/sssp-test.sh
+++ b/dataset/test-scripts/topc/sssp-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-EXEDIR="../../../../gunrock_build/bin"
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
 EXECUTION="sssp"
-#DATADIR="../../large"
-DATADIR="/data/gunrock_dataset/large"
 SETTING=" --src=0 --undirected --iteration-num=10"
 NAME[0]="soc-LiveJournal1" && DO_A[0]="0.200"   && DO_B[0]="0.1" && T_MODE[0]="LB_CULL"
 NAME[1]="soc-orkut"        && DO_A[1]="0.012"   && DO_B[1]="0.1" && T_MODE[1]="LB_CULL"

--- a/dataset/test-scripts/topc/topc-test.sh
+++ b/dataset/test-scripts/topc/topc-test.sh
@@ -1,1 +1,6 @@
-sh bfs-test.sh && sh sssp-test.sh && sh bc-test.sh && sh pr-test.sh && sh cc-test.sh
+
+EXEDIR=${1:-"../../../../gunrock_build/bin"}
+DATADIR=${2:-"/data/gunrock_dataset/large"}
+for algo in bfs sssp bc pr cc; do
+    ./${algo}-test.sh "$EXEDIR" "$DATADIR"
+done


### PR DESCRIPTION
The variables EXEDIR and DATADIR can now directly be passed from commandline.
Also added a small README.md to document this process of benchmarking on topc datasets.