### PR TITLE
Added check for invalid graph (exits if number of nodes is negative).

### DIFF
--- a/gunrock/graphio/market.cuh
+++ b/gunrock/graphio/market.cuh
@@ -363,7 +363,8 @@ int ReadMarketStream(
 
 		if (ll_row < 1 || ll_col < 1)
                 {
-                    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices cannot start with 0.\n");
+                    fprintf(stderr, "\nError Invalid graph: Bad MTX format, 
+			    indices cannot start with 0.\n");
                     if (coo) free(coo);
                     exit(1);
                 }

--- a/gunrock/graphio/market.cuh
+++ b/gunrock/graphio/market.cuh
@@ -71,14 +71,6 @@ int ReadLabelStream(
                 return -1;
             }
 
-            if (ll_nodes_x != ll_nodes_y)
-            {
-                fprintf(stderr,
-                        "Error parsing node labels: not square (%lld, %lld)\n",
-                        ll_nodes_x, ll_nodes_y);
-                return -1;
-            }
-
             nodes = ll_nodes_x;
 
             if (!quiet)
@@ -332,6 +324,14 @@ int ReadMarketStream(
             {
                 num_input = sscanf(line, "%lld %lld %lf",
                     &ll_row, &ll_col, &lf_value);
+
+		if (ll_row <  1 || ll_col <  1)
+		{
+		    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices cannot start with 0.\n");
+		    if (coo) free(coo);
+		    exit(1); 
+		}		
+
                 if (typeid(Value) == typeid(float) || typeid(Value) == typeid(double))
                     ll_value = (Value)lf_value;
                 else ll_value = (Value)(lf_value + 1e-10);
@@ -346,8 +346,7 @@ int ReadMarketStream(
 
                 else if (array || num_input < 2)
                 {
-                    fprintf(stderr,
-                            "Error parsing MARKET graph: badly formed edge\n");
+                    fprintf(stderr,                            "Error parsing MARKET graph: badly formed edge\n");
                     if (coo) free(coo);
                     return -1;
                 }
@@ -360,6 +359,13 @@ int ReadMarketStream(
             else
             {
                 num_input = sscanf(line, "%lld %lld", &ll_row, &ll_col);
+
+		if (ll_row < 1 || ll_col < 1)
+                {
+                    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices cannot start with 0.\n");
+                    if (coo) free(coo);
+                    exit(1);
+                }
 
                 if (array && (num_input == 1))
                 {

--- a/gunrock/graphio/market.cuh
+++ b/gunrock/graphio/market.cuh
@@ -327,9 +327,9 @@ int ReadMarketStream(
 
 		if (ll_row <  1 || ll_col <  1)
 		{
-		    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices
-			    cannot start with 0.\n");
-		    if (coo) free(coo);
+		    fprintf(stderr, 
+			    "\nInvalid graph: Bad MTX format, indices cannot start with 0.\n");
+		    free(coo);
 		    exit(1); 
 		}		
 
@@ -363,9 +363,9 @@ int ReadMarketStream(
 
 		if (ll_row < 1 || ll_col < 1)
                 {
-                    fprintf(stderr, "\nError Invalid graph: Bad MTX format, 
-			    indices cannot start with 0.\n");
-                    if (coo) free(coo);
+                    fprintf(stderr,
+			    "\nInvalid graph: Bad MTX format, indices cannot start with 0.\n");
+                    free(coo);
                     exit(1);
                 }
 

--- a/gunrock/graphio/market.cuh
+++ b/gunrock/graphio/market.cuh
@@ -327,7 +327,8 @@ int ReadMarketStream(
 
 		if (ll_row <  1 || ll_col <  1)
 		{
-		    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices cannot start with 0.\n");
+		    fprintf(stderr, "\nError Invalid graph: Bad MTX format, indices
+			    cannot start with 0.\n");
 		    if (coo) free(coo);
 		    exit(1); 
 		}		

--- a/gunrock/graphio/utils.cuh
+++ b/gunrock/graphio/utils.cuh
@@ -65,8 +65,7 @@ SizeT RandomNode (SizeT num_nodes)
     return node_id % num_nodes;
 }
 
-template <typename VertexId, typename SizeT, typename Value>
-void RemoveStandaloneNodes(
+template <typename VertexId, typename SizeT, typename Value>void RemoveStandaloneNodes(
     Csr<VertexId, SizeT, Value>* graph, bool quiet = false)
 {
     SizeT nodes = graph->nodes;
@@ -92,7 +91,8 @@ void RemoveStandaloneNodes(
         SizeT node_start = (long long)(nodes) * thread_num / num_threads;
         SizeT node_end   = (long long)(nodes) * (thread_num + 1) / num_threads;
 
-        for (SizeT    edge = edge_start; edge < edge_end; edge++)
+	
+	for (SizeT    edge = edge_start; edge < edge_end; edge++)
             marker[column_indices[edge]] = 1;
         for (VertexId node = node_start; node < node_end; node++)
             if (row_offsets[node] != row_offsets[node + 1])
@@ -140,6 +140,13 @@ void RemoveStandaloneNodes(
     }
 
     nodes = nodes - block_offsets[num_threads];
+
+    if (nodes < 0)
+    {
+	printf("Invalid graph error. The number of nodes is negative.\n");
+	exit(1);
+    }	
+
     memcpy(row_offsets, new_offsets, sizeof(SizeT) * (nodes + 1));
     if (values != NULL) memcpy(values, new_values, sizeof(Value) * nodes);
     if (!quiet)

--- a/gunrock/graphio/utils.cuh
+++ b/gunrock/graphio/utils.cuh
@@ -65,7 +65,8 @@ SizeT RandomNode (SizeT num_nodes)
     return node_id % num_nodes;
 }
 
-template <typename VertexId, typename SizeT, typename Value>void RemoveStandaloneNodes(
+template <typename VertexId, typename SizeT, typename Value>
+void RemoveStandaloneNodes(
     Csr<VertexId, SizeT, Value>* graph, bool quiet = false)
 {
     SizeT nodes = graph->nodes;


### PR DESCRIPTION
Use of gdb indicated that invalid graphs generated a negative number of nodes, which caused a segmentation fault. This check will display an error message if this is the case and terminate the program. 

This can be tested with the simple graph:
2 2 2
1 1
2 2

which used to seg fault but now will cause an exit out of the program. 