### PR TITLE
Support OpenMP auto build on Mac OS X with GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tests/*/*.txt
 
 # Ignore cmake configure_file() files
 gunrock/util/gitsha1.c
+
+# Ignore build directory
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ add_definitions("-DGUNROCKVERSION=${gunrock_VERSION_MAJOR}.${gunrock_VERSION_MIN
 
 cmake_minimum_required(VERSION 2.8)
 
+# enable @rpath in the install name for any shared library being built
+# note: it is planned that a future version of CMake will enable this by default
+set(CMAKE_MACOSX_RPATH 1)
+
 # begin /* Added make check target to improve ctest command */
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
 # end /* Added make check target to improve ctest command */

--- a/cmake/FindOpenMP.cmake
+++ b/cmake/FindOpenMP.cmake
@@ -22,7 +22,7 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       SET(OPENMP_SOURCES_DIR ${CMAKE_BINARY_DIR}/omp)
       SET(OPENMP_INSTALL_DIR ${CMAKE_BINARY_DIR}/install/omp)
       SET(OPENMP_INCLUDE "${OPENMP_INSTALL_DIR}/include" CACHE PATH "openmp include directory." FORCE)
-      SET(OPENMP_LIB "${OPENMP_INSTALL_DIR}/lib/libomp.dylib" CACHE FILEPATH "openmp library." FORCE)
+      SET(OPENMP_LIBRARY "${OPENMP_INSTALL_DIR}/lib/libomp.dylib" CACHE FILEPATH "openmp library." FORCE)
 
       # external dependencies log output
       SET(EXTERNAL_PROJECT_LOG_ARGS
@@ -54,7 +54,7 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
       )   
       ADD_LIBRARY(openmp SHARED IMPORTED GLOBAL)
-      SET_PROPERTY(TARGET openmp PROPERTY IMPORTED_LOCATION ${OPENMP_LIB})
+      SET_PROPERTY(TARGET openmp PROPERTY IMPORTED_LOCATION ${OPENMP_LIBRARY})
       ADD_DEPENDENCIES(openmp extern_openmp)
       SET(OPENMP_LIB openmp)
     ENDIF()

--- a/cmake/FindOpenMP.cmake
+++ b/cmake/FindOpenMP.cmake
@@ -16,18 +16,52 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     #added for OpenMP on OS X using Macports
     FIND_PATH(OPENMP_INCLUDE omp.h PATHS ${CMAKE_INCLUDE_PATH})
     FIND_LIBRARY(OPENMP_LIB NAMES libgomp.dylib libomp.dylib libiomp5.dylib PATHS ${CMAKE_LIBRARY_PATH})
-    IF (OPENMP_INCLUDE OR OPENMP_LIB)
+    IF (NOT OPENMP_INCLUDE OR NOT OPENMP_LIB)
+      # If OpenMP doesn't exist, cmake automatically build and install it on Mac OS X.
+      INCLUDE(ExternalProject)
+      SET(OPENMP_SOURCES_DIR ${CMAKE_BINARY_DIR}/omp)
+      SET(OPENMP_INSTALL_DIR ${CMAKE_BINARY_DIR}/install/omp)
+      SET(OPENMP_INCLUDE "${OPENMP_INSTALL_DIR}/include" CACHE PATH "openmp include directory." FORCE)
+      SET(OPENMP_LIB "${OPENMP_INSTALL_DIR}/lib/libomp.dylib" CACHE FILEPATH "openmp library." FORCE)
 
-      link_directories("/opt/local/lib" "/opt/local/lib/libomp")
-      include_directories("/opt/local/include" "/opt/local/include/libomp")
+      # external dependencies log output
+      SET(EXTERNAL_PROJECT_LOG_ARGS
+          LOG_DOWNLOAD    0     # Wrap download in script to log output
+          LOG_UPDATE      1     # Wrap update in script to log output
+          LOG_CONFIGURE   1     # Wrap configure in script to log output
+          LOG_BUILD       0     # Wrap build in script to log output
+          LOG_TEST        1     # Wrap test in script to log output
+          LOG_INSTALL     0     # Wrap install in script to log output
+      )
 
-      SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-      MESSAGE(STATUS "Found OpenMP (-libomp)")
-    ELSE()
-      MESSAGE(WARNING "OpenMP (-libomp) was requested but support was not found")
-    ENDIF(OPENMP_INCLUDE OR OPENMP_LIB)
+      ExternalProject_Add(
+        extern_openmp
+        ${EXTERNAL_PROJECT_LOG_ARGS}
+        GIT_REPOSITORY  https://github.com/llvm-mirror/openmp.git
+        GIT_TAG         1d9902d5b99ee93e0bb3f886e08414a81f21cd2a
+        PREFIX          ${OPENMP_SOURCES_DIR}
+        UPDATE_COMMAND  ""
+        CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                        -DCMAKE_INSTALL_PREFIX=${OPENMP_INSTALL_DIR}
+                        -DCMAKE_INSTALL_LIBDIR=${OPENMP_INSTALL_DIR}/lib
+                        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                        -DBUILD_TESTING=OFF
+        CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${OPENMP_INSTALL_DIR}
+                         -DCMAKE_INSTALL_LIBDIR:PATH=${OPENMP_INSTALL_DIR}/lib
+                         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+      )   
+      ADD_LIBRARY(openmp SHARED IMPORTED GLOBAL)
+      SET_PROPERTY(TARGET openmp PROPERTY IMPORTED_LOCATION ${OPENMP_LIB})
+      ADD_DEPENDENCIES(openmp extern_openmp)
+      SET(OPENMP_LIB openmp)
+    ENDIF()
 
+    LINK_LIBRARIES("${OPENMP_LIB}")
+    INCLUDE_DIRECTORIES("${OPENMP_INCLUDE}")
+    MESSAGE(STATUS "Found OpenMP (-libomp)")
   ENDIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
 ELSE()

--- a/cmake/SetSubProject.cmake
+++ b/cmake/SetSubProject.cmake
@@ -40,11 +40,3 @@ if (METIS_LIBRARY)
 endif()
 # end /* Link Metis and Boost */
 
-# begin /* Link OpenMP (libomp) for OSX */
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib")
-    target_link_libraries(${PROJECT_NAME} "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-# end /* Link OpenMP (libomp) for OSX */

--- a/gunrock/CMakeLists.txt
+++ b/gunrock/CMakeLists.txt
@@ -42,12 +42,3 @@ target_link_libraries(gunrock ${Boost_LIBRARIES})
 if (METIS_LIBRARY)
 	target_link_libraries(gunrock ${METIS_LIBRARY})
 endif ()
-
-# OpenMP on OS X/clang
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    link_directories("/opt/local/lib" "/opt/local/lib/libomp")
-    include_directories("/opt/local/include" "/opt/local/include/libomp")
-    target_link_libraries(gunrock "omp")
-  endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
Fix #314

```
gangl@GangLiao ~/G/g/g/build> cmake -DGUNROCK_GENCODE_SM30=ON -DGUNROCK_GENCODE_SM50=ON ..
-- The C compiler identification is AppleClang 8.0.0.8000038
-- The CXX compiler identification is AppleClang 8.0.0.8000038
-- Check for working C compiler: /Applications/Xcode8.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode8.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode8.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode8.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
-- Found CUDA: /usr/local/cuda (found suitable version "8.0", minimum required is "7.5")
-- Boost version: 1.61.0
-- Boost version: 1.61.0
-- Found the following Boost libraries:
--   system
--   filesystem
--   timer
--   chrono
-- Found OpenMP (-libomp)
-- Found Metis
-- Project Added: bc
-- Project Added: bfs
-- Project Added: cc
-- Project Added: pr
-- Project Added: sssp
-- Project Added: hits
-- Project Added: salsa
-- Project Added: wtf
-- Project Added: topk
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/liaogang/Google Drive/github/gunrock/build


gangl@GangLiao ~/G/g/g/build> make -j12
Scanning dependencies of target extern_openmp
[  0%] Creating directories for 'extern_openmp'
[  1%] Performing download step (git clone) for 'extern_openmp'
Cloning into 'extern_openmp'...
Note: checking out '1d9902d5b99ee93e0bb3f886e08414a81f21cd2a'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 1d9902d... [OMPT] Omissionin in OMPT Formatting
[  3%] No update step for 'extern_openmp'
[  3%] No patch step for 'extern_openmp'
[  4%] Performing configure step for 'extern_openmp'
-- extern_openmp configure command succeeded.  See also /Users/liaogang/Google Drive/github/gunrock/build/omp/src/extern_openmp-stamp/extern_openmp-configure-*.log
[  5%] Performing build step for 'extern_openmp'
Scanning dependencies of target libomp-needed-headers
[  5%] Generating kmp_i18n_default.inc
[  5%] Generating kmp_i18n_id.inc
[  5%] Built target libomp-needed-headers
Scanning dependencies of target omp
[  8%] Building C object runtime/src/CMakeFiles/omp.dir/thirdparty/ittnotify/ittnotify_static.c.o
[ 13%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_atomic.cpp.o
[ 16%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_csupport.cpp.o
[ 16%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_alloc.cpp.o
[ 22%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_itt.cpp.o
[ 22%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_debug.cpp.o
[ 25%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_environment.cpp.o
[ 27%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_error.cpp.o
[ 30%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_i18n.cpp.o
[ 33%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_global.cpp.o
[ 36%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_io.cpp.o
[ 38%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_runtime.cpp.o
[ 41%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_settings.cpp.o
[ 44%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_str.cpp.o
[ 47%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_tasking.cpp.o
[ 50%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_taskq.cpp.o
[ 52%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_threadprivate.cpp.o
[ 55%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_utility.cpp.o
[ 58%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_barrier.cpp.o
[ 61%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_wait_release.cpp.o
[ 63%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_affinity.cpp.o
[ 66%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_dispatch.cpp.o
[ 69%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_lock.cpp.o
[ 72%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_sched.cpp.o
[ 75%] Building CXX object runtime/src/CMakeFiles/omp.dir/z_Linux_util.cpp.o
[ 77%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_gsupport.cpp.o
[ 80%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_taskdeps.cpp.o
[ 83%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_cancel.cpp.o
[ 86%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_ftn_cdecl.cpp.o
[ 88%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_ftn_extra.cpp.o
[ 91%] Building CXX object runtime/src/CMakeFiles/omp.dir/kmp_version.cpp.o
[ 94%] Building CXX object runtime/src/CMakeFiles/omp.dir/ompt-general.cpp.o
[ 97%] Building C object runtime/src/CMakeFiles/omp.dir/z_Linux_asm.S.o
[100%] Linking C shared library libomp.dylib
[100%] Built target omp
[  6%] Performing install step for 'extern_openmp'
[  5%] Built target libomp-needed-headers
[100%] Built target omp
Install the project...
-- Install configuration: "Release"
-- Installing: /Users/liaogang/Google Drive/github/gunrock/build/install/omp/lib/libomp.dylib
-- Installing: /Users/liaogang/Google Drive/github/gunrock/build/install/omp/include/omp.h
-- Installing: /Users/liaogang/Google Drive/github/gunrock/build/install/omp/include/ompt.h
[  7%] Completed 'extern_openmp'
[  7%] Built target extern_openmp
[  9%] Building NVCC (Device) object tests/bc/CMakeFiles/bc.dir/__/__/externals/moderngpu/src/bc_generated_mgpucontext.cu.o
[  9%] Building NVCC (Device) object gunrock/CMakeFiles/gunrock.dir/__/externals/moderngpu/src/gunrock_generated_mgpucontext.cu.o
[ 10%] Building NVCC (Device) object tests/bfs/CMakeFiles/bfs.dir/__/__/externals/moderngpu/src/bfs_generated_mgpucontext.cu.o
[ 11%] Building NVCC (Device) object tests/cc/CMakeFiles/cc.dir/__/__/externals/moderngpu/src/cc_generated_mgpucontext.cu.o
[ 12%] Building NVCC (Device) object tests/bfs/CMakeFiles/bfs.dir/bfs_generated_test_bfs.cu.o
[ 13%] Building NVCC (Device) object tests/sssp/CMakeFiles/sssp.dir/__/__/externals/moderngpu/src/sssp_generated_mgpucontext.cu.o
[ 13%] Building NVCC (Device) object tests/bc/CMakeFiles/bc.dir/bc_generated_test_bc.cu.o
[ 14%] Building NVCC (Device) object tests/hits/CMakeFiles/hits.dir/__/__/externals/moderngpu/src/hits_generated_mgpucontext.cu.o
[ 16%] Building NVCC (Device) object tests/salsa/CMakeFiles/salsa.dir/__/__/externals/moderngpu/src/salsa_generated_mgpucontext.cu.o
[ 16%] Building NVCC (Device) object tests/pr/CMakeFiles/pr.dir/__/__/externals/moderngpu/src/pr_generated_mgpucontext.cu.o
[ 17%] Building NVCC (Device) object tests/wtf/CMakeFiles/wtf.dir/__/__/externals/moderngpu/src/wtf_generated_mgpucontext.cu.o
[ 18%] Building NVCC (Device) object tests/topk/CMakeFiles/topk.dir/__/__/externals/moderngpu/src/topk_generated_mgpucontext.cu.o
[ 19%] Building NVCC (Device) object tests/sssp/CMakeFiles/sssp.dir/sssp_generated_test_sssp.cu.o
[ 20%] Building NVCC (Device) object tests/cc/CMakeFiles/cc.dir/cc_generated_test_cc.cu.o
[ 21%] Building NVCC (Device) object tests/salsa/CMakeFiles/salsa.dir/salsa_generated_test_salsa.cu.o
[ 22%] Building NVCC (Device) object tests/wtf/CMakeFiles/wtf.dir/wtf_generated_test_wtf.cu.o
[ 22%] Building NVCC (Device) object tests/pr/CMakeFiles/pr.dir/pr_generated_test_pr.cu.o
[ 23%] Building NVCC (Device) object gunrock/CMakeFiles/gunrock.dir/app/bfs/gunrock_generated_bfs_app.cu.o
[ 24%] Building NVCC (Device) object tests/topk/CMakeFiles/topk.dir/topk_generated_test_topk.cu.o
[ 25%] Building NVCC (Device) object tests/bc/CMakeFiles/bc.dir/__/__/gunrock/util/bc_generated_test_utils.cu.o
[ 26%] Building NVCC (Device) object tests/cc/CMakeFiles/cc.dir/__/__/gunrock/util/cc_generated_test_utils.cu.o
[ 27%] Building NVCC (Device) object tests/hits/CMakeFiles/hits.dir/hits_generated_test_hits.cu.o
[ 28%] Building NVCC (Device) object gunrock/CMakeFiles/gunrock.dir/app/bc/gunrock_generated_bc_app.cu.o
[ 29%] Building NVCC (Device) object tests/topk/CMakeFiles/topk.dir/__/__/gunrock/util/topk_generated_test_utils.cu.o
[ 30%] Building NVCC (Device) object tests/wtf/CMakeFiles/wtf.dir/__/__/gunrock/util/wtf_generated_test_utils.cu.o
[ 31%] Building NVCC (Device) object tests/salsa/CMakeFiles/salsa.dir/__/__/gunrock/util/salsa_generated_test_utils.cu.o
[ 32%] Building NVCC (Device) object tests/wtf/CMakeFiles/wtf.dir/__/__/gunrock/util/wtf_generated_error_utils.cu.o
[ 33%] Building NVCC (Device) object tests/sssp/CMakeFiles/sssp.dir/__/__/gunrock/util/sssp_generated_test_utils.cu.o

```