### PR TITLE
Workaround for the Volta + CUDA 9.1 bug

### DIFF
--- a/gunrock/app/pr/pr_enactor.cuh
+++ b/gunrock/app/pr/pr_enactor.cuh
@@ -388,25 +388,6 @@ struct PRIteration : public IterationBase <
                 util::cpu_mt::PrintMessage("Filter start.",
                     thread_num, enactor_stats->iteration, peer_);
              // filter kernel
-            /*gunrock::oprtr::filter::LaunchKernel
-                <FilterKernelPolicy, Problem, PrFunctor>(
-                enactor_stats->filter_grid_size,
-                FilterKernelPolicy::THREADS,
-                (size_t)0,
-                stream,
-                typename PrFunctor::LabelT(),//enactor_stats->iteration,
-                frontier_attribute->queue_reset,
-                frontier_attribute->queue_index,
-                frontier_attribute->queue_length,
-                frontier_queue->keys[frontier_attribute->selector  ].GetPointer(util::DEVICE),      // d_in_queue
-                (Value*)NULL,
-                (VertexId*)NULL,//frontier_queue->keys[frontier_attribute->selector^1].GetPointer(util::DEVICE),// d_out_queue
-                d_data_slice,
-                (unsigned char*)NULL,
-                work_progress[0],
-                frontier_queue->keys[frontier_attribute->selector  ].GetSize(),           // max_in_queue
-                util::MaxValue<VertexId>(), //frontier_queue->keys[frontier_attribute->selector^1].GetSize(),         // max_out_queue
-                enactor_stats->filter_kernel_stats);*/
             gunrock::oprtr::filter::LaunchKernel
                 <FilterKernelPolicy, Problem, PrFunctor>(
                 enactor_stats[0],
@@ -429,6 +410,7 @@ struct PRIteration : public IterationBase <
                 util::MaxValue<SizeT>(),
                 enactor_stats -> filter_kernel_stats,
                 false); // do not filter
+
             if (enactor -> debug)
                 util::cpu_mt::PrintMessage("Filter end.",
                     thread_num, enactor_stats -> iteration, peer_);

--- a/gunrock/oprtr/advance_base.cuh
+++ b/gunrock/oprtr/advance_base.cuh
@@ -118,23 +118,25 @@ __device__ __forceinline__ void PrepareQueue(
     util::CtaWorkProgress<SizeT> &work_progress)
 {
     // Determine work decomposition
-    if (threadIdx.x == 0 && blockIdx.x == 0)
+    if (threadIdx.x == 0)
     {
-        // obtain problem size
-        if (queue_reset)
-        {
-            work_progress.StoreQueueLength(input_queue_length, queue_index);
-        }
-        else
-        {
+        if (!queue_reset)
             input_queue_length = work_progress.LoadQueueLength(queue_index);
+
+        if (blockIdx.x == 0)
+        {
+            // obtain problem size
+            if (queue_reset)
+            {
+                work_progress.StoreQueueLength(input_queue_length, queue_index);
+            }
+
+            work_progress.Enqueue(output_queue_length[0], queue_index + 1);
+
+            // Reset our next outgoing queue counter to zero
+            work_progress.StoreQueueLength(0, queue_index + 2);
+            //work_progress.PrepResetSteal(queue_index + 1);
         }
-
-        work_progress.Enqueue(output_queue_length[0], queue_index + 1);
-
-        // Reset our next outgoing queue counter to zero
-        work_progress.StoreQueueLength(0, queue_index + 2);
-        //work_progress.PrepResetSteal(queue_index + 1);
     }
 
     // Barrier to protect work decomposition

--- a/gunrock/oprtr/all_edges_advance/kernel.cuh
+++ b/gunrock/oprtr/all_edges_advance/kernel.cuh
@@ -115,14 +115,12 @@ struct Dispatch<KernelPolicy, Problem, Functor,
         //__shared__ typename KernelPolicy::SmemStorage smem;
         //SizeT *output_queue_length;
 
-        if (threadIdx.x == 0 && blockIdx.x == 0)
+        if (threadIdx.x == 0)
         {
-            if (queue_reset)
-            {
-                work_progress.StoreQueueLength(input_queue_length, queue_index);
-            } else {
+            if (!queue_reset)
                 input_queue_length = work_progress.LoadQueueLength(queue_index);
-            }
+            else if (blockIdx.x == 0)
+                work_progress.StoreQueueLength(input_queue_length, queue_index);
         }
         //if (threadIdx.x == blockDim.x -1)
         //    output_queue_length = work_progress.GetQueueCounter(queue_index + 1);

--- a/gunrock/oprtr/bypass_filter/kernel.cuh
+++ b/gunrock/oprtr/bypass_filter/kernel.cuh
@@ -77,9 +77,10 @@ struct Dispatch<KernelPolicy, Problem, Functor, true>
         while (pos - threadIdx.x < input_queue_length)
         {
             bool to_process = true;
-            VertexId input_item = (d_in_queue == NULL) ? pos : d_in_queue[pos];
+            VertexId input_item;
             if (pos < input_queue_length)
             {
+                input_item = (d_in_queue == NULL) ? pos : d_in_queue[pos];
                 to_process = Functor::CondFilter(
                     util::InvalidValue<VertexId>(),
                     input_item,

--- a/gunrock/oprtr/edge_map_partitioned_backward/kernel.cuh
+++ b/gunrock/oprtr/edge_map_partitioned_backward/kernel.cuh
@@ -137,28 +137,25 @@ struct Dispatch<KernelPolicy, ProblemData, Functor, true>
         //}
 
         // Determine work decomposition
-        if (threadIdx.x == 0 && blockIdx.x == 0) {
-
-            // obtain problem size
-            if (queue_reset)
-            {
-                work_progress.StoreQueueLength(input_queue_len, queue_index);
-            }
-            else
-            {
+        if (threadIdx.x == 0) 
+        {
+            if (!queue_reset)
                 input_queue_len = work_progress.LoadQueueLength(queue_index);
 
-                // Signal to host that we're done
-                //if (input_queue_len == 0) {
-                //    if (d_done) d_done[0] = input_queue_len;
-                //}
+            if (blockIdx.x == 0)
+            {
+                // obtain problem size
+                if (queue_reset)
+                {
+                    work_progress.StoreQueueLength(input_queue_len, queue_index);
+                }
+
+                work_progress.Enqueue(output_queue_len[0], queue_index+1);
+
+                // Reset our next outgoing queue counter to zero
+                work_progress.StoreQueueLength(0, queue_index + 2);
+                work_progress.PrepResetSteal(queue_index + 1);
             }
-
-            work_progress.Enqueue(output_queue_len[0], queue_index+1);
-
-            // Reset our next outgoing queue counter to zero
-            work_progress.StoreQueueLength(0, queue_index + 2);
-            work_progress.PrepResetSteal(queue_index + 1);
         }
 
         // Barrier to protect work decomposition
@@ -340,28 +337,24 @@ struct Dispatch<KernelPolicy, ProblemData, Functor, true>
         //}
 
         // Determine work decomposition
-        if (blockIdx.x == 0 && threadIdx.x == 0) {
-
+        if (threadIdx.x == 0)
+        {
             // obtain problem size
-            if (queue_reset)
-            {
-                work_progress.StoreQueueLength(input_queue_len, queue_index);
-            }
-            else
-            {
+            if (!queue_reset)
                 input_queue_len = work_progress.LoadQueueLength(queue_index);
 
-                // Signal to host that we're done
-                //if (input_queue_len == 0) {
-                //    if (d_done) d_done[0] = input_queue_len;
-                //}
+            if (blockIdx.x == 0)
+            {                
+                if (queue_reset)
+                {
+                    work_progress.StoreQueueLength(input_queue_len, queue_index);
+                }
+                work_progress.Enqueue(output_queue_len[0], queue_index+1);
+
+                // Reset our next outgoing queue counter to zero
+                work_progress.StoreQueueLength(0, queue_index + 2);
+                work_progress.PrepResetSteal(queue_index + 1);
             }
-
-            work_progress.Enqueue(output_queue_len[0], queue_index+1);
-
-            // Reset our next outgoing queue counter to zero
-            work_progress.StoreQueueLength(0, queue_index + 2);
-            work_progress.PrepResetSteal(queue_index + 1);
         }
 
         // Barrier to protect work decomposition

--- a/gunrock/oprtr/edge_map_partitioned_cull/kernel.cuh
+++ b/gunrock/oprtr/edge_map_partitioned_cull/kernel.cuh
@@ -267,7 +267,6 @@ struct Dispatch<KernelPolicy, Problem, Functor,
         __syncthreads();*/
         KernelPolicy::BlockScanT::Scan(thread_output_count, output_pos, smem_storage.scan_space);
 
-
         //KernelPolicy::BlockScanT(smem_storage.cub_storage.scan_space)
         //    .ExclusiveSum(thread_output_count, output_pos);
         if (threadIdx.x == KernelPolicy::THREADS -1)
@@ -735,6 +734,7 @@ struct Dispatch<KernelPolicy, Problem, Functor,
                 work_progress);
         }
         __syncthreads();
+        //printf("(%3d, %3d) 1\n", blockIdx.x, threadIdx.x);
 
         SizeT* row_offsets = (output_inverse_graph) ?
             d_inverse_row_offsets :
@@ -809,6 +809,7 @@ struct Dispatch<KernelPolicy, Problem, Functor,
             }
 
             __syncthreads();
+            //printf("(%3d, %3d) 2\n", blockIdx.x, threadIdx.x);
 
 
             //printf("(%4d, %4d)  : block_input = %d ~ %d, block_output = %d ~ %d, %d\n",

--- a/gunrock/oprtr/filter/kernel.cuh
+++ b/gunrock/oprtr/filter/kernel.cuh
@@ -410,6 +410,7 @@ struct Dispatch<Parameter, BY_PASS>
         cudaError_t retval = cudaSuccess;
         int num_blocks = parameter.num_elements / KernelPolicy::THREADS / 4 + 1;
         if (num_blocks > 480) num_blocks = 480;
+
         gunrock::oprtr::bypass_filter::Kernel<
             KernelPolicy,
             typename Parameter::Problem,

--- a/gunrock/util/types.cuh
+++ b/gunrock/util/types.cuh
@@ -14,7 +14,7 @@
 
 #pragma once
 
-
+#include <float.h>
 
 namespace gunrock {
 namespace util {

--- a/tests/BaseMakefile.mk
+++ b/tests/BaseMakefile.mk
@@ -23,6 +23,7 @@ OSUPPER = $(shell uname -s 2>/dev/null | tr [:lower:] [:upper:])
 # Gen targets
 #-------------------------------------------------------------------------------
 
+GEN_SM70 = -gencode=arch=compute_70,code=\"sm_70,compute_70\"
 GEN_SM61 = -gencode=arch=compute_61,code=\"sm_61,compute_61\"
 GEN_SM60 = -gencode=arch=compute_60,code=\"sm_60,compute_60\"
 GEN_SM52 = -gencode=arch=compute_52,code=\"sm_52,compute_52\"
@@ -30,7 +31,7 @@ GEN_SM50 = -gencode=arch=compute_50,code=\"sm_50,compute_50\"
 GEN_SM37 = -gencode=arch=compute_37,code=\"sm_37,compute_37\"
 GEN_SM35 = -gencode=arch=compute_35,code=\"sm_35,compute_35\"
 GEN_SM30 = -gencode=arch=compute_30,code=\"sm_30,compute_30\"
-SM_TARGETS = $(GEN_SM35) #$(GEN_SM35) $(GEN_SM60) $(GEN_SM61) 
+SM_TARGETS = $(GEN_SM70) $(GEN_SM35) $(GEN_SM61) #$(GEN_SM61) 
 #-------------------------------------------------------------------------------
 # Libs
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Adding two _all(1) to sync threads within a warp keeps WarpScan running