### PR TITLE
Add initial dockerfiles

### DIFF
--- a/docker/ubuntu16.04-cuda9.0/dockerfile
+++ b/docker/ubuntu16.04-cuda9.0/dockerfile
@@ -1,0 +1,15 @@
+FROM nvidia/cuda:9.0-devel-ubuntu16.04
+
+########################
+# Install Dependencies #
+########################
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake git libboost-all-dev && rm -rf /var/lib/apt/lists/*
+
+#################
+# Build Gunrock #
+#################
+
+RUN git clone --recursive https://github.com/gunrock/gunrock.git && \
+    cd gunrock && mkdir build && cd build && cmake .. && make -j$(nproc)

--- a/docker/ubuntu16.04-cuda9.1/dockerfile
+++ b/docker/ubuntu16.04-cuda9.1/dockerfile
@@ -1,0 +1,15 @@
+FROM nvidia/cuda:9.1-devel-ubuntu16.04
+
+########################
+# Install Dependencies #
+########################
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake git libboost-all-dev && rm -rf /var/lib/apt/lists/*
+
+#################
+# Build Gunrock #
+#################
+
+RUN git clone --recursive https://github.com/gunrock/gunrock.git && \
+    cd gunrock && mkdir build && cd build && cmake .. && make -j$(nproc)


### PR DESCRIPTION
Note: this is minimum working Dockerfile (no metis, always build master branch, ...), we can start from here and further improve it. Following are my in/outs, you can reference when creating documents.

Build:

```
cd docker/ubuntu16.04-cuda9.1/
docker build -t gunrock .
```

Example run:

```
$ nvidia-docker run -ti gunrock
root@b159c6898b1b:/# cd gunrock/build/
root@b159c6898b1b:/gunrock/build# make test
Running tests...
Test project /gunrock/build
      Start  1: TEST_BFS
 1/11 Test  #1: TEST_BFS .........................   Passed   19.09 sec
      Start  2: TEST_BC
 2/11 Test  #2: TEST_BC ..........................   Passed    3.40 sec
      Start  3: TEST_CC
 3/11 Test  #3: TEST_CC ..........................   Passed    1.11 sec
      Start  4: TEST_SSSP
 4/11 Test  #4: TEST_SSSP ........................   Passed    3.78 sec
      Start  5: TEST_PAGERANK
 5/11 Test  #5: TEST_PAGERANK ....................   Passed    5.34 sec
      Start  6: TEST_TOPK
 6/11 Test  #6: TEST_TOPK ........................   Passed    1.28 sec
      Start  7: SHARED_LIB_TEST_BFS
 7/11 Test  #7: SHARED_LIB_TEST_BFS ..............   Passed    8.52 sec
      Start  8: SHARED_LIB_TEST_BC
 8/11 Test  #8: SHARED_LIB_TEST_BC ...............   Passed    0.27 sec
      Start  9: SHARED_LIB_TEST_CC
 9/11 Test  #9: SHARED_LIB_TEST_CC ...............   Passed    0.25 sec
      Start 10: SHARED_LIB_TEST_SSSP
10/11 Test #10: SHARED_LIB_TEST_SSSP .............   Passed    0.28 sec
      Start 11: SHARED_LIB_TEST_PAGERANK
11/11 Test #11: SHARED_LIB_TEST_PAGERANK .........   Passed    0.30 sec

100% tests passed, 0 tests failed out of 11

Total Test time (real) =  43.65 sec
root@b159c6898b1b:/gunrock/build#
```