### PR TITLE
`--random-edge-values` flag

### DIFF
--- a/gunrock/graphio/graphio.cuh
+++ b/gunrock/graphio/graphio.cuh
@@ -55,6 +55,13 @@ cudaError_t UseParameters(
         "Whether " + graph_prefix + " graph is undirected",
         __FILE__, __LINE__));
 
+    GUARD_CU(parameters.Use<bool>(
+        graph_prefix + "random-edge-values",
+        util::OPTIONAL_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+        false,
+        "Whether " + graph_prefix + " graph edge values are randomly generate",
+        __FILE__, __LINE__));
+
     GUARD_CU(parameters.Use<float>(
         graph_prefix + "edge-value-range",
         util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,

--- a/gunrock/graphio/graphio.cuh
+++ b/gunrock/graphio/graphio.cuh
@@ -59,7 +59,9 @@ cudaError_t UseParameters(
         graph_prefix + "random-edge-values",
         util::OPTIONAL_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
         false,
-        "Whether " + graph_prefix + " graph edge values are randomly generate",
+        "If true, " + graph_prefix + 
+        " graph edge values are randomly generated when missing. " +
+        "If false, they are set to 1.",
         __FILE__, __LINE__));
 
     GUARD_CU(parameters.Use<float>(

--- a/gunrock/graphio/market.cuh
+++ b/gunrock/graphio/market.cuh
@@ -76,6 +76,8 @@ cudaError_t ReadMarketStream(
     bool quiet = parameters.Get<bool>("quiet");
     bool undirected             = parameters.Get<bool>(
         graph_prefix + "undirected");
+    bool random_edge_values = parameters.Get<bool>(
+        graph_prefix + "random-edge-values");
     ValueT edge_value_min       = parameters.Get<ValueT>(
         graph_prefix + "edge-value-min");
     ValueT edge_value_range     = parameters.Get<ValueT>(
@@ -236,20 +238,27 @@ cudaError_t ReadMarketStream(
 
                 else if (num_input == 2)
                 {
-                    //double x = rand() * 1.0;
-                    //ll_value = std::remainder(rand(), edge_value_range);
-                    auto x = rand();
-                    double int_x = 0;
-                    std::modf(x * 1.0 / edge_value_range, &int_x);
-                    ll_value = x - int_x * edge_value_range;
-                    //if (ll_value < 0)
-                    //    ll_value += edge_value_range;
-                    ll_value += edge_value_min;
-                    //printf("edge_values[%lld] = %lf, range = %lf, min = %lf\n",
-                    //    edges_read, ll_value, edge_value_range, edge_value_min);
-                    //std::cout << "edge_values[" << edges_read << "] = "
-                    //    << ll_value << ", range = " << edge_value_range
-                    //    << ", min = " << edge_value_min << std::endl;
+                    if(random_edge_values)
+                    {
+                        //double x = rand() * 1.0;
+                        //ll_value = std::remainder(rand(), edge_value_range);
+                        auto x = rand();
+                        double int_x = 0;
+                        std::modf(x * 1.0 / edge_value_range, &int_x);
+                        ll_value = x - int_x * edge_value_range;
+                        //if (ll_value < 0)
+                        //    ll_value += edge_value_range;
+                        ll_value += edge_value_min;
+                        //printf("edge_values[%lld] = %lf, range = %lf, min = %lf\n",
+                        //    edges_read, ll_value, edge_value_range, edge_value_min);
+                        //std::cout << "edge_values[" << edges_read << "] = "
+                        //    << ll_value << ", range = " << edge_value_range
+                        //    << ", min = " << edge_value_min << std::endl;
+                    }
+                    else
+                    {
+                        ll_value = 1;
+                    }
                 }
                 //graph.CooT::edge_values[edges_read] = ll_value;
             }

--- a/gunrock/graphio/rgg.cuh
+++ b/gunrock/graphio/rgg.cuh
@@ -156,6 +156,7 @@ cudaError_t Build(
     if (parameters.UseDefault("dataset"))
         parameters.Set<std::string>("dataset", dataset);
 
+    bool random_edge_values = parameters.Get<bool>(graph_prefix + "random-edge-values");
     double edge_value_range = parameters.Get<double>(graph_prefix + "edge-value-range");
     double edge_value_min   = parameters.Get<double>(graph_prefix + "edge-value-min");
 
@@ -317,7 +318,15 @@ cudaError_t Build(
                     col_index[counter] = peer;
                     if (GraphT::FLAG & graph::HAS_EDGE_VALUES)
                     {
-                        values[counter] = distribution(engine) * edge_value_range + edge_value_min;
+                        if(random_edge_values)
+                        {
+                            values[counter] = distribution(engine) * edge_value_range + edge_value_min;
+                        }
+                        else
+                        {
+                            values[counter] = 1;
+                        }
+
                     }
                     counter++;
                 }

--- a/gunrock/graphio/rmat.cuh
+++ b/gunrock/graphio/rmat.cuh
@@ -286,6 +286,7 @@ cudaError_t Build(
     if (!parameters.UseDefault(graph_prefix + "graph-seed"))
         seed = parameters.Get<int>(graph_prefix + "graph-seed");
 
+    bool random_edge_values = parameters.Get<bool>(graph_prefix + "random-edge-values");
     double edge_value_range = parameters.Get<double>(graph_prefix + "edge-value-range");
     double edge_value_min   = parameters.Get<double>(graph_prefix + "edge-value-min");
 
@@ -345,7 +346,15 @@ cudaError_t Build(
             graph.CooT::edge_pairs[e].y = v - 1; // zero based
             if (GraphT::FLAG & graph::HAS_EDGE_VALUES)
             {
-                graph.CooT::edge_values[e] = Sprng(rand_state) * edge_value_range + edge_value_min;
+                if(random_edge_values)
+                {
+                    graph.CooT::edge_values[e] = Sprng(rand_state) * edge_value_range + edge_value_min;
+                }
+                else
+                {
+                    graph.CooT::edge_values[e] = 1;
+                }
+
             }
         }
     }

--- a/gunrock/graphio/small_world.cuh
+++ b/gunrock/graphio/small_world.cuh
@@ -88,6 +88,7 @@ cudaError_t Build(
     if (parameters.UseDefault("dataset"))
         parameters.Set<std::string>("dataset", dataset);
 
+    bool random_edge_values = parameters.Get<bool>(graph_prefix + "random-edge-values");
     double edge_value_range = parameters.Get<double>(graph_prefix + "edge-value-range");
     double edge_value_min   = parameters.Get<double>(graph_prefix + "edge-value-min");
 
@@ -128,7 +129,15 @@ cudaError_t Build(
         graph.CooT::edge_pairs[edge_counter].y = u;
         if (GraphT::FLAG & graph::HAS_EDGE_VALUES)
         {
-            graph.CooT::edge_values[edge_counter] = distribution(engine) * edge_value_range + edge_value_min;
+            if(random_edge_values)
+            {
+                graph.CooT::edge_values[edge_counter] = distribution(engine) * edge_value_range + edge_value_min;
+            }
+            else
+            {
+                graph.CooT::edge_values[edge_counter] = 1;
+            }
+
         }
         edge_counter ++;
     }


### PR DESCRIPTION
Adding `--random-edge-values` flag to change the default behavior when edge weights are not specified in the input file.  Previously, Gunrock generated random edge weights by default, which was surprising behavior.  This PR changes the default behavior s.t. edge weights are set to 1 by default.  The old behavior can be exposed via the `--random-edge-values`  flag.