### PR TITLE
[dev-refactor] HIVE VN application

### DIFF
--- a/gunrock/app/vn/vn_app.cu
+++ b/gunrock/app/vn/vn_app.cu
@@ -6,9 +6,9 @@
 // ----------------------------------------------------------------------------
 
 /**
- * @file sssp_app.cu
+ * @file vn_app.cu
  *
- * @brief single-source shortest path (SSSP) application
+ * @brief single-source shortest path (vn) application
  */
 
 #include <gunrock/gunrock.h>
@@ -22,12 +22,12 @@
 #include <gunrock/app/test_base.cuh>
 
 // single-source shortest path includes
-#include <gunrock/app/sssp/sssp_enactor.cuh>
-#include <gunrock/app/sssp/sssp_test.cuh>
+#include <gunrock/app/vn/vn_enactor.cuh>
+#include <gunrock/app/vn/vn_test.cuh>
 
 namespace gunrock {
 namespace app {
-namespace sssp {
+namespace vn {
 
 cudaError_t UseParameters(util::Parameters &parameters)
 {
@@ -40,7 +40,7 @@ cudaError_t UseParameters(util::Parameters &parameters)
         "src",
         util::REQUIRED_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
         "0",
-        "<Vertex-ID|random|largestdegree> The source vertices\n"
+        "<Vertex-IDs|random|largestdegree> The source vertices\n"
         "\tIf random, randomly select non-zero degree vertices;\n"
         "\tIf largestdegree, select vertices with largest degrees",
         __FILE__, __LINE__));
@@ -56,20 +56,20 @@ cudaError_t UseParameters(util::Parameters &parameters)
 }
 
 /**
- * @brief Run SSSP tests
+ * @brief Run vn tests
  * @tparam     GraphT        Type of the graph
  * @tparam     ValueT        Type of the distances
  * @param[in]  parameters    Excution parameters
  * @param[in]  graph         Input graph
  * @param[in]  ref_distances Reference distances
- * @param[in]  target        Whether to perform the SSSP
+ * @param[in]  target        Whether to perform the vn
  * \return cudaError_t error message(s), if any
  */
 template <typename GraphT, typename ValueT = typename GraphT::ValueT>
 cudaError_t RunTests(
     util::Parameters &parameters,
     GraphT           &graph,
-    ValueT **ref_distances = NULL,
+    ValueT *ref_distances = NULL,
     util::Location target = util::DEVICE)
 {
     cudaError_t retval = cudaSuccess;
@@ -85,9 +85,9 @@ cudaError_t RunTests(
     bool mark_pred  = parameters.Get<bool>("mark-pred");
     int  num_runs   = parameters.Get<int >("num-runs");
     std::string validation = parameters.Get<std::string>("validation");
-    std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
-    int  num_srcs   = srcs   .size();
-    util::Info info("SSSP", parameters, graph); // initialize Info structure
+    std::vector<VertexT> srcs_vector = parameters.Get<std::vector<VertexT>>("srcs");
+    int  num_srcs   = srcs_vector.size();
+    util::Info info("vn", parameters, graph); // initialize Info structure
 
     // Allocate host-side array (for both reference and GPU-computed results)
     ValueT  *h_distances = new ValueT[graph.nodes];
@@ -96,40 +96,48 @@ cudaError_t RunTests(
     // Allocate problem and enactor on GPU, and initialize them
     ProblemT problem(parameters);
     EnactorT enactor;
-    //util::PrintMsg("Before init");
+    // util::PrintMsg("Before init");
     GUARD_CU(problem.Init(graph  , target));
     GUARD_CU(enactor.Init(problem, target));
-    //util::PrintMsg("After init");
+    // util::PrintMsg("After init");
     cpu_timer.Stop();
     parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
     //info.preprocess_time = cpu_timer.ElapsedMillis();
 
-    // perform SSSP
-    VertexT src;
+    // perform vn
+    VertexT *srcs = new VertexT[num_srcs];
+    for(SizeT i = 0; i < num_srcs; ++i) {
+        srcs[i] = srcs_vector[i];
+    }
+    
     for (int run_num = 0; run_num < num_runs; ++run_num)
     {
-        src = srcs[run_num % num_srcs];
-        GUARD_CU(problem.Reset(src, target));
-        GUARD_CU(enactor.Reset(src, target));
+        GUARD_CU(problem.Reset(srcs, num_srcs, target));
+        GUARD_CU(enactor.Reset(srcs, num_srcs, target));
         util::PrintMsg("__________________________", !quiet_mode);
 
         cpu_timer.Start();
-        GUARD_CU(enactor.Enact(src));
+        GUARD_CU(enactor.Enact(srcs));
         cpu_timer.Stop();
         info.CollectSingleRun(cpu_timer.ElapsedMillis());
 
+        std::string src_msg = "";
+        for(SizeT i = 0; i < num_srcs; ++i) {
+            src_msg += std::to_string(srcs[i]);
+            if(i != num_srcs - 1) src_msg += ",";
+        }
         util::PrintMsg("--------------------------\nRun "
             + std::to_string(run_num) + " elapsed: "
-            + std::to_string(cpu_timer.ElapsedMillis()) + " ms, src = "
-            + std::to_string(src) + ", #iterations = "
+            + std::to_string(cpu_timer.ElapsedMillis()) + " ms, srcs = "
+            + src_msg + ", #iterations = " // TODO -- fix docs
             + std::to_string(enactor.enactor_slices[0]
                 .enactor_stats.iteration), !quiet_mode);
         if (validation == "each")
         {
             GUARD_CU(problem.Extract(h_distances, h_preds));
-            SizeT num_errors = app::sssp::Validate_Results(
-                parameters, graph, src, h_distances, h_preds,
-                ref_distances == NULL ? NULL : ref_distances[run_num % num_srcs],
+            SizeT num_errors = app::vn::Validate_Results(
+                parameters, graph, srcs, h_distances, h_preds,
+                ref_distances == NULL ? NULL : ref_distances,
                 NULL, false);
         }
     }
@@ -139,9 +147,9 @@ cudaError_t RunTests(
     GUARD_CU(problem.Extract(h_distances, h_preds));
     if (validation == "last")
     {
-        SizeT num_errors = app::sssp::Validate_Results(
-            parameters, graph, src, h_distances, h_preds,
-            ref_distances == NULL ? NULL : ref_distances[(num_runs -1) % num_srcs]);
+        SizeT num_errors = app::vn::Validate_Results(
+            parameters, graph, srcs, h_distances, h_preds,
+            ref_distances == NULL ? NULL : ref_distances);
     }
 
     // compute running statistics
@@ -162,12 +170,12 @@ cudaError_t RunTests(
     return retval;
 }
 
-} // namespace sssp
+} // namespace vn
 } // namespace app
 } // namespace gunrock
 
 /*
- * @brief Entry of gunrock_sssp function
+ * @brief Entry of gunrock_vn function
  * @tparam     GraphT     Type of the graph
  * @tparam     ValueT     Type of the distances
  * @param[in]  parameters Excution parameters
@@ -177,15 +185,16 @@ cudaError_t RunTests(
  * \return     double     Return accumulated elapsed times for all runs
  */
 template <typename GraphT, typename ValueT = typename GraphT::ValueT>
-double gunrock_sssp(
+double gunrock_vn(
     gunrock::util::Parameters &parameters,
     GraphT &graph,
-    ValueT **distances,
-    typename GraphT::VertexT **preds = NULL)
+    ValueT *distances,
+    typename GraphT::VertexT *preds = NULL)
 {
     typedef typename GraphT::VertexT VertexT;
-    typedef gunrock::app::sssp::Problem<GraphT  > ProblemT;
-    typedef gunrock::app::sssp::Enactor<ProblemT> EnactorT;
+    typedef typename GraphT::SizeT SizeT;
+    typedef gunrock::app::vn::Problem<GraphT  > ProblemT;
+    typedef gunrock::app::vn::Enactor<ProblemT> EnactorT;
     gunrock::util::CpuTimer cpu_timer;
     gunrock::util::Location target = gunrock::util::DEVICE;
     double total_time = 0;
@@ -198,51 +207,54 @@ double gunrock_sssp(
     problem.Init(graph  , target);
     enactor.Init(problem, target);
 
-    std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+    std::vector<VertexT> srcs_vector = parameters.Get<std::vector<VertexT>>("srcs");
+    SizeT num_srcs = srcs_vector.size();
+    VertexT *srcs = new VertexT[num_srcs];
+    for(SizeT i = 0; i < num_srcs; ++i) {
+        srcs[i] = srcs_vector[i];
+    }
+    
     int num_runs = parameters.Get<int>("num-runs");
-    int num_srcs = srcs.size();
     for (int run_num = 0; run_num < num_runs; ++run_num)
     {
-        int src_num = run_num % num_srcs;
-        VertexT src = srcs[src_num];
-        problem.Reset(src, target);
-        enactor.Reset(src, target);
+        problem.Reset(srcs, num_srcs, target);
+        enactor.Reset(srcs, num_srcs, target);
 
         cpu_timer.Start();
-        enactor.Enact(src);
+        enactor.Enact(srcs);
         cpu_timer.Stop();
 
         total_time += cpu_timer.ElapsedMillis();
-        problem.Extract(distances[src_num],
-            preds == NULL ? NULL : preds[src_num]);
+        problem.Extract(distances, preds == NULL ? NULL : preds);
     }
 
     enactor.Release(target);
     problem.Release(target);
-    srcs.clear();
+    srcs_vector.clear();
     return total_time;
 }
 
-/*
- * @brief Simple interface take in graph as CSR format
- * @param[in]  num_nodes   Number of veritces in the input graph
- * @param[in]  num_edges   Number of edges in the input graph
- * @param[in]  row_offsets CSR-formatted graph input row offsets
- * @param[in]  col_indices CSR-formatted graph input column indices
- * @param[in]  edge_values CSR-formatted graph input edge weights
- * @param[in]  num_runs    Number of runs to perform SSSP
- * @param[in]  sources     Sources to begin traverse, one for each run
- * @param[in]  mark_preds  Whether to output predecessor info
- * @param[out] distances   Return shortest distance to source per vertex
- * @param[out] preds       Return predecessors of each vertex
- * \return     double      Return accumulated elapsed times for all runs
- */
+
+//  * @brief Simple interface take in graph as CSR format
+//  * @param[in]  num_nodes   Number of veritces in the input graph
+//  * @param[in]  num_edges   Number of edges in the input graph
+//  * @param[in]  row_offsets CSR-formatted graph input row offsets
+//  * @param[in]  col_indices CSR-formatted graph input column indices
+//  * @param[in]  edge_values CSR-formatted graph input edge weights
+//  * @param[in]  num_runs    Number of runs to perform vn
+//  * @param[in]  sources     Sources to begin traverse, one for each run
+//  * @param[in]  mark_preds  Whether to output predecessor info
+//  * @param[out] distances   Return shortest distance to source per vertex
+//  * @param[out] preds       Return predecessors of each vertex
+//  * \return     double      Return accumulated elapsed times for all runs
+ 
+
 template <
     typename VertexT = int,
     typename SizeT   = int,
     typename GValueT = unsigned int,
-    typename SSSPValueT = GValueT>
-double sssp(
+    typename vnValueT = GValueT>
+double vn(
     const SizeT        num_nodes,
     const SizeT        num_edges,
     const SizeT       *row_offsets,
@@ -251,8 +263,8 @@ double sssp(
     const int          num_runs,
           VertexT     *sources,
     const bool         mark_pred,
-          SSSPValueT **distances,
-          VertexT    **preds = NULL)
+          vnValueT    *distances,
+          VertexT     *preds = NULL)
 {
     typedef typename gunrock::app::TestGraph<VertexT, SizeT, GValueT,
         gunrock::graph::HAS_EDGE_VALUES | gunrock::graph::HAS_CSR>
@@ -260,9 +272,9 @@ double sssp(
     typedef typename GraphT::CsrT CsrT;
 
     // Setup parameters
-    gunrock::util::Parameters parameters("sssp");
+    gunrock::util::Parameters parameters("vn");
     gunrock::graphio::UseParameters(parameters);
-    gunrock::app::sssp::UseParameters(parameters);
+    gunrock::app::vn::UseParameters(parameters);
     gunrock::app::UseParameters_test(parameters);
     parameters.Parse_CommandLine(0, NULL);
     parameters.Set("graph-type", "by-pass");
@@ -271,6 +283,7 @@ double sssp(
     std::vector<VertexT> srcs;
     for (int i = 0; i < num_runs; i ++)
         srcs.push_back(sources[i]);
+    
     parameters.Set("srcs", srcs);
 
     bool quiet = parameters.Get<bool>("quiet");
@@ -283,8 +296,8 @@ double sssp(
     graph.FromCsr(graph.csr(), true, quiet);
     gunrock::graphio::LoadGraph(parameters, graph);
 
-    // Run the SSSP
-    double elapsed_time = gunrock_sssp(parameters, graph, distances, preds);
+    // Run the vn
+    double elapsed_time = gunrock_vn(parameters, graph, distances, preds);
 
     // Cleanup
     graph.Release();

--- a/gunrock/app/vn/vn_app.cu
+++ b/gunrock/app/vn/vn_app.cu
@@ -1,0 +1,300 @@
+// ----------------------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------------------
+
+/**
+ * @file sssp_app.cu
+ *
+ * @brief single-source shortest path (SSSP) application
+ */
+
+#include <gunrock/gunrock.h>
+
+// Utilities and correctness-checking
+#include <gunrock/util/test_utils.cuh>
+
+// Graph definations
+#include <gunrock/graphio/graphio.cuh>
+#include <gunrock/app/app_base.cuh>
+#include <gunrock/app/test_base.cuh>
+
+// single-source shortest path includes
+#include <gunrock/app/sssp/sssp_enactor.cuh>
+#include <gunrock/app/sssp/sssp_test.cuh>
+
+namespace gunrock {
+namespace app {
+namespace sssp {
+
+cudaError_t UseParameters(util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(UseParameters_app    (parameters));
+    GUARD_CU(UseParameters_problem(parameters));
+    GUARD_CU(UseParameters_enactor(parameters));
+
+    GUARD_CU(parameters.Use<std::string>(
+        "src",
+        util::REQUIRED_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
+        "0",
+        "<Vertex-ID|random|largestdegree> The source vertices\n"
+        "\tIf random, randomly select non-zero degree vertices;\n"
+        "\tIf largestdegree, select vertices with largest degrees",
+        __FILE__, __LINE__));
+
+    GUARD_CU(parameters.Use<int>(
+        "src-seed",
+        util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
+        util::PreDefinedValues<int>::InvalidValue,
+        "seed to generate random sources",
+        __FILE__, __LINE__));
+
+    return retval;
+}
+
+/**
+ * @brief Run SSSP tests
+ * @tparam     GraphT        Type of the graph
+ * @tparam     ValueT        Type of the distances
+ * @param[in]  parameters    Excution parameters
+ * @param[in]  graph         Input graph
+ * @param[in]  ref_distances Reference distances
+ * @param[in]  target        Whether to perform the SSSP
+ * \return cudaError_t error message(s), if any
+ */
+template <typename GraphT, typename ValueT = typename GraphT::ValueT>
+cudaError_t RunTests(
+    util::Parameters &parameters,
+    GraphT           &graph,
+    ValueT **ref_distances = NULL,
+    util::Location target = util::DEVICE)
+{
+    cudaError_t retval = cudaSuccess;
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef Problem<GraphT  > ProblemT;
+    typedef Enactor<ProblemT> EnactorT;
+    util::CpuTimer    cpu_timer, total_timer;
+    cpu_timer.Start(); total_timer.Start();
+
+    // parse configurations from parameters
+    bool quiet_mode = parameters.Get<bool>("quiet");
+    bool mark_pred  = parameters.Get<bool>("mark-pred");
+    int  num_runs   = parameters.Get<int >("num-runs");
+    std::string validation = parameters.Get<std::string>("validation");
+    std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+    int  num_srcs   = srcs   .size();
+    util::Info info("SSSP", parameters, graph); // initialize Info structure
+
+    // Allocate host-side array (for both reference and GPU-computed results)
+    ValueT  *h_distances = new ValueT[graph.nodes];
+    VertexT *h_preds = (mark_pred) ? new VertexT[graph.nodes] : NULL;
+
+    // Allocate problem and enactor on GPU, and initialize them
+    ProblemT problem(parameters);
+    EnactorT enactor;
+    //util::PrintMsg("Before init");
+    GUARD_CU(problem.Init(graph  , target));
+    GUARD_CU(enactor.Init(problem, target));
+    //util::PrintMsg("After init");
+    cpu_timer.Stop();
+    parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
+    //info.preprocess_time = cpu_timer.ElapsedMillis();
+
+    // perform SSSP
+    VertexT src;
+    for (int run_num = 0; run_num < num_runs; ++run_num)
+    {
+        src = srcs[run_num % num_srcs];
+        GUARD_CU(problem.Reset(src, target));
+        GUARD_CU(enactor.Reset(src, target));
+        util::PrintMsg("__________________________", !quiet_mode);
+
+        cpu_timer.Start();
+        GUARD_CU(enactor.Enact(src));
+        cpu_timer.Stop();
+        info.CollectSingleRun(cpu_timer.ElapsedMillis());
+
+        util::PrintMsg("--------------------------\nRun "
+            + std::to_string(run_num) + " elapsed: "
+            + std::to_string(cpu_timer.ElapsedMillis()) + " ms, src = "
+            + std::to_string(src) + ", #iterations = "
+            + std::to_string(enactor.enactor_slices[0]
+                .enactor_stats.iteration), !quiet_mode);
+        if (validation == "each")
+        {
+            GUARD_CU(problem.Extract(h_distances, h_preds));
+            SizeT num_errors = app::sssp::Validate_Results(
+                parameters, graph, src, h_distances, h_preds,
+                ref_distances == NULL ? NULL : ref_distances[run_num % num_srcs],
+                NULL, false);
+        }
+    }
+
+    cpu_timer.Start();
+    // Copy out results
+    GUARD_CU(problem.Extract(h_distances, h_preds));
+    if (validation == "last")
+    {
+        SizeT num_errors = app::sssp::Validate_Results(
+            parameters, graph, src, h_distances, h_preds,
+            ref_distances == NULL ? NULL : ref_distances[(num_runs -1) % num_srcs]);
+    }
+
+    // compute running statistics
+    info.ComputeTraversalStats(enactor, h_distances);
+    //Display_Memory_Usage(problem);
+    #ifdef ENABLE_PERFORMANCE_PROFILING
+        //Display_Performance_Profiling(enactor);
+    #endif
+
+    // Clean up
+    GUARD_CU(enactor.Release(target));
+    GUARD_CU(problem.Release(target));
+    delete[] h_distances  ; h_distances   = NULL;
+    delete[] h_preds      ; h_preds       = NULL;
+    cpu_timer.Stop(); total_timer.Stop();
+
+    info.Finalize(cpu_timer.ElapsedMillis(), total_timer.ElapsedMillis());
+    return retval;
+}
+
+} // namespace sssp
+} // namespace app
+} // namespace gunrock
+
+/*
+ * @brief Entry of gunrock_sssp function
+ * @tparam     GraphT     Type of the graph
+ * @tparam     ValueT     Type of the distances
+ * @param[in]  parameters Excution parameters
+ * @param[in]  graph      Input graph
+ * @param[out] distances  Return shortest distance to source per vertex
+ * @param[out] preds      Return predecessors of each vertex
+ * \return     double     Return accumulated elapsed times for all runs
+ */
+template <typename GraphT, typename ValueT = typename GraphT::ValueT>
+double gunrock_sssp(
+    gunrock::util::Parameters &parameters,
+    GraphT &graph,
+    ValueT **distances,
+    typename GraphT::VertexT **preds = NULL)
+{
+    typedef typename GraphT::VertexT VertexT;
+    typedef gunrock::app::sssp::Problem<GraphT  > ProblemT;
+    typedef gunrock::app::sssp::Enactor<ProblemT> EnactorT;
+    gunrock::util::CpuTimer cpu_timer;
+    gunrock::util::Location target = gunrock::util::DEVICE;
+    double total_time = 0;
+    if (parameters.UseDefault("quiet"))
+        parameters.Set("quiet", true);
+
+    // Allocate problem and enactor on GPU, and initialize them
+    ProblemT problem(parameters);
+    EnactorT enactor;
+    problem.Init(graph  , target);
+    enactor.Init(problem, target);
+
+    std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+    int num_runs = parameters.Get<int>("num-runs");
+    int num_srcs = srcs.size();
+    for (int run_num = 0; run_num < num_runs; ++run_num)
+    {
+        int src_num = run_num % num_srcs;
+        VertexT src = srcs[src_num];
+        problem.Reset(src, target);
+        enactor.Reset(src, target);
+
+        cpu_timer.Start();
+        enactor.Enact(src);
+        cpu_timer.Stop();
+
+        total_time += cpu_timer.ElapsedMillis();
+        problem.Extract(distances[src_num],
+            preds == NULL ? NULL : preds[src_num]);
+    }
+
+    enactor.Release(target);
+    problem.Release(target);
+    srcs.clear();
+    return total_time;
+}
+
+/*
+ * @brief Simple interface take in graph as CSR format
+ * @param[in]  num_nodes   Number of veritces in the input graph
+ * @param[in]  num_edges   Number of edges in the input graph
+ * @param[in]  row_offsets CSR-formatted graph input row offsets
+ * @param[in]  col_indices CSR-formatted graph input column indices
+ * @param[in]  edge_values CSR-formatted graph input edge weights
+ * @param[in]  num_runs    Number of runs to perform SSSP
+ * @param[in]  sources     Sources to begin traverse, one for each run
+ * @param[in]  mark_preds  Whether to output predecessor info
+ * @param[out] distances   Return shortest distance to source per vertex
+ * @param[out] preds       Return predecessors of each vertex
+ * \return     double      Return accumulated elapsed times for all runs
+ */
+template <
+    typename VertexT = int,
+    typename SizeT   = int,
+    typename GValueT = unsigned int,
+    typename SSSPValueT = GValueT>
+double sssp(
+    const SizeT        num_nodes,
+    const SizeT        num_edges,
+    const SizeT       *row_offsets,
+    const VertexT     *col_indices,
+    const GValueT     *edge_values,
+    const int          num_runs,
+          VertexT     *sources,
+    const bool         mark_pred,
+          SSSPValueT **distances,
+          VertexT    **preds = NULL)
+{
+    typedef typename gunrock::app::TestGraph<VertexT, SizeT, GValueT,
+        gunrock::graph::HAS_EDGE_VALUES | gunrock::graph::HAS_CSR>
+        GraphT;
+    typedef typename GraphT::CsrT CsrT;
+
+    // Setup parameters
+    gunrock::util::Parameters parameters("sssp");
+    gunrock::graphio::UseParameters(parameters);
+    gunrock::app::sssp::UseParameters(parameters);
+    gunrock::app::UseParameters_test(parameters);
+    parameters.Parse_CommandLine(0, NULL);
+    parameters.Set("graph-type", "by-pass");
+    parameters.Set("mark-pred", mark_pred);
+    parameters.Set("num-runs", num_runs);
+    std::vector<VertexT> srcs;
+    for (int i = 0; i < num_runs; i ++)
+        srcs.push_back(sources[i]);
+    parameters.Set("srcs", srcs);
+
+    bool quiet = parameters.Get<bool>("quiet");
+    GraphT graph;
+    // Assign pointers into gunrock graph format
+    graph.CsrT::Allocate(num_nodes, num_edges, gunrock::util::HOST);
+    graph.CsrT::row_offsets   .SetPointer(row_offsets, gunrock::util::HOST);
+    graph.CsrT::column_indices.SetPointer(col_indices, gunrock::util::HOST);
+    graph.CsrT::edge_values   .SetPointer(edge_values, gunrock::util::HOST);
+    graph.FromCsr(graph.csr(), true, quiet);
+    gunrock::graphio::LoadGraph(parameters, graph);
+
+    // Run the SSSP
+    double elapsed_time = gunrock_sssp(parameters, graph, distances, preds);
+
+    // Cleanup
+    graph.Release();
+    srcs.clear();
+
+    return elapsed_time;
+}
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/gunrock/app/vn/vn_app.cu
+++ b/gunrock/app/vn/vn_app.cu
@@ -290,10 +290,10 @@ double vn(
     GraphT graph;
     // Assign pointers into gunrock graph format
     graph.CsrT::Allocate(num_nodes, num_edges, gunrock::util::HOST);
-    graph.CsrT::row_offsets   .SetPointer(row_offsets, gunrock::util::HOST);
-    graph.CsrT::column_indices.SetPointer(col_indices, gunrock::util::HOST);
-    graph.CsrT::edge_values   .SetPointer(edge_values, gunrock::util::HOST);
-    graph.FromCsr(graph.csr(), true, quiet);
+    graph.CsrT::row_offsets   .SetPointer(row_offsets, num_nodes + 1, gunrock::util::HOST);
+    graph.CsrT::column_indices.SetPointer(col_indices, num_edges, gunrock::util::HOST);
+    // graph.CsrT::edge_values   .SetPointer(edge_values, gunrock::util::HOST);
+    // graph.FromCsr(graph.csr(), true, quiet);
     gunrock::graphio::LoadGraph(parameters, graph);
 
     // Run the vn

--- a/gunrock/app/vn/vn_enactor.cuh
+++ b/gunrock/app/vn/vn_enactor.cuh
@@ -1,0 +1,401 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * sssp_enactor.cuh
+ *
+ * @brief SSSP Problem Enactor
+ */
+
+#pragma once
+
+#include <gunrock/app/enactor_base.cuh>
+#include <gunrock/app/enactor_iteration.cuh>
+#include <gunrock/app/enactor_loop.cuh>
+#include <gunrock/app/sssp/sssp_problem.cuh>
+#include <gunrock/oprtr/oprtr.cuh>
+
+namespace gunrock {
+namespace app {
+namespace sssp {
+
+/**
+ * @brief Speciflying parameters for SSSP Enactor
+ * @param parameters The util::Parameter<...> structure holding all parameter info
+ * \return cudaError_t error message(s), if any
+ */
+cudaError_t UseParameters_enactor(util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(app::UseParameters_enactor(parameters));
+    return retval;
+}
+
+/**
+ * @brief defination of SSSP iteration loop
+ * @tparam EnactorT Type of enactor
+ */
+template <typename EnactorT>
+struct SSSPIterationLoop : public IterationLoopBase
+    <EnactorT, Use_FullQ | Push |
+    (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
+    Update_Predecessors : 0x0)>
+{
+    typedef typename EnactorT::VertexT VertexT;
+    typedef typename EnactorT::SizeT   SizeT;
+    typedef typename EnactorT::ValueT  ValueT;
+    typedef typename EnactorT::Problem::GraphT::CsrT CsrT;
+    typedef typename EnactorT::Problem::GraphT::GpT  GpT;
+    typedef IterationLoopBase
+        <EnactorT, Use_FullQ | Push |
+        (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
+         Update_Predecessors : 0x0)> BaseIterationLoop;
+
+    SSSPIterationLoop() : BaseIterationLoop() {}
+
+    /**
+     * @brief Core computation of sssp, one iteration
+     * @param[in] peer_ Which GPU peers to work on, 0 means local
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Core(int peer_ = 0)
+    {
+        // Data sssp that works on
+        auto         &data_slice         =   this -> enactor ->
+            problem -> data_slices[this -> gpu_num][0];
+        auto         &enactor_slice      =   this -> enactor ->
+            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
+        auto         &enactor_stats      =   enactor_slice.enactor_stats;
+        auto         &graph              =   data_slice.sub_graph[0];
+        auto         &distances          =   data_slice.distances;
+        auto         &labels             =   data_slice.labels;
+        auto         &preds              =   data_slice.preds;
+        //auto         &row_offsets        =   graph.CsrT::row_offsets;
+        auto         &weights            =   graph.CsrT::edge_values;
+        auto         &original_vertex    =   graph.GpT::original_vertex;
+        auto         &frontier           =   enactor_slice.frontier;
+        auto         &oprtr_parameters   =   enactor_slice.oprtr_parameters;
+        auto         &retval             =   enactor_stats.retval;
+        //auto         &stream             =   enactor_slice.stream;
+        auto         &iteration          =   enactor_stats.iteration;
+
+        // The advance operation
+        auto advance_op = [distances, weights, original_vertex, preds]
+        __host__ __device__ (
+            const VertexT &src, VertexT &dest, const SizeT &edge_id,
+            const VertexT &input_item, const SizeT &input_pos,
+            SizeT &output_pos) -> bool
+        {
+            ValueT src_distance = Load<cub::LOAD_CG>(distances + src);
+            ValueT edge_weight  = Load<cub::LOAD_CS>(weights + edge_id);
+            ValueT new_distance = src_distance + edge_weight;
+
+            // Check if the destination node has been claimed as someone's child
+            ValueT old_distance = atomicMin(distances + dest, new_distance);
+
+            if (new_distance < old_distance)
+            {
+                if (!preds.isEmpty())
+                {
+                    VertexT pred = src;
+                    if (!original_vertex.isEmpty())
+                        pred = original_vertex[src];
+                    Store(preds + dest, pred);
+                }
+                return true;
+            }
+            return false;
+        };
+
+        // The filter operation
+        auto filter_op = [labels, iteration] __host__ __device__(
+            const VertexT &src, VertexT &dest, const SizeT &edge_id,
+            const VertexT &input_item, const SizeT &input_pos,
+            SizeT &output_pos) -> bool
+        {
+            if (!util::isValid(dest)) return false;
+            if (labels[dest] == iteration) return false;
+            labels[dest] = iteration;
+            return true;
+        };
+
+        oprtr_parameters.label = iteration + 1;
+        // Call the advance operator, using the advance operation
+        GUARD_CU(oprtr::Advance<oprtr::OprtrType_V2V>(
+            graph.csr(), frontier.V_Q(), frontier.Next_V_Q(),
+            oprtr_parameters, advance_op, filter_op));
+
+        if (oprtr_parameters.advance_mode != "LB_CULL" &&
+            oprtr_parameters.advance_mode != "LB_LIGHT_CULL")
+        {
+            frontier.queue_reset = false;
+            // Call the filter operator, using the filter operation
+            GUARD_CU(oprtr::Filter<oprtr::OprtrType_V2V>(
+                graph.csr(), frontier.V_Q(), frontier.Next_V_Q(),
+                oprtr_parameters, filter_op));
+        }
+
+        // Get back the resulted frontier length
+        GUARD_CU(frontier.work_progress.GetQueueLength(
+            frontier.queue_index, frontier.queue_length,
+            false, oprtr_parameters.stream, true));
+
+        return retval;
+    }
+
+    /**
+     * @brief Routine to combine received data and local data
+     * @tparam NUM_VERTEX_ASSOCIATES Number of data associated with each transmition item, typed VertexT
+     * @tparam NUM_VALUE__ASSOCIATES Number of data associated with each transmition item, typed ValueT
+     * @param  received_length The numver of transmition items received
+     * @param[in] peer_ which peer GPU the data came from
+     * \return cudaError_t error message(s), if any
+     */
+    template <
+        int NUM_VERTEX_ASSOCIATES,
+        int NUM_VALUE__ASSOCIATES>
+    cudaError_t ExpandIncoming(SizeT &received_length, int peer_)
+    {
+        auto         &data_slice         =   this -> enactor ->
+            problem -> data_slices[this -> gpu_num][0];
+        auto         &enactor_slice      =   this -> enactor ->
+            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
+        auto iteration = enactor_slice.enactor_stats.iteration;
+        auto         &distances          =   data_slice.distances;
+        auto         &labels             =   data_slice.labels;
+        auto         &preds              =   data_slice.preds;
+        auto          label              =   this -> enactor ->
+            mgpu_slices[this -> gpu_num].in_iteration[iteration % 2][peer_];
+
+        auto expand_op = [distances, labels, label, preds]
+        __host__ __device__(
+            VertexT &key, const SizeT &in_pos,
+            VertexT *vertex_associate_ins,
+            ValueT  *value__associate_ins) -> bool
+        {
+            ValueT in_val  = value__associate_ins[in_pos];
+            ValueT old_val = atomicMin(distances + key, in_val);
+            if (old_val <= in_val)
+                return false;
+            if (labels[key] == label)
+                return false;
+            labels[key] = label;
+            if (!preds.isEmpty())
+                preds[key] = vertex_associate_ins[in_pos];
+            return true;
+        };
+
+        cudaError_t retval = BaseIterationLoop:: template ExpandIncomingBase
+            <NUM_VERTEX_ASSOCIATES, NUM_VALUE__ASSOCIATES>
+            (received_length, peer_, expand_op);
+        return retval;
+    }
+}; // end of SSSPIteration
+
+/**
+ * @brief SSSP enactor class.
+ * @tparam _Problem Problem type we process on
+ * @tparam ARRAY_FLAG Flags for util::Array1D used in the enactor
+ * @tparam cudaHostRegisterFlag Flags for util::Array1D used in the enactor
+ */
+template <
+    typename _Problem,
+    util::ArrayFlag ARRAY_FLAG = util::ARRAY_NONE,
+    unsigned int cudaHostRegisterFlag = cudaHostRegisterDefault>
+class Enactor :
+    public EnactorBase<
+        typename _Problem::GraphT,
+        typename _Problem::LabelT,
+        typename _Problem::ValueT,
+        ARRAY_FLAG, cudaHostRegisterFlag>
+{
+public:
+    // Definations
+    typedef _Problem                   Problem ;
+    typedef typename Problem::SizeT    SizeT   ;
+    typedef typename Problem::VertexT  VertexT ;
+    typedef typename Problem::ValueT   ValueT  ;
+    typedef typename Problem::GraphT   GraphT  ;
+    typedef typename Problem::LabelT   LabelT  ;
+    typedef EnactorBase<GraphT , LabelT, ValueT, ARRAY_FLAG, cudaHostRegisterFlag>
+        BaseEnactor;
+    typedef Enactor<Problem, ARRAY_FLAG, cudaHostRegisterFlag>
+        EnactorT;
+    typedef SSSPIterationLoop<EnactorT> IterationT;
+
+    // Members
+    Problem     *problem   ;
+    IterationT  *iterations;
+
+    /**
+     * \addtogroup PublicInterface
+     * @{
+     */
+
+    /**
+     * @brief SSSPEnactor constructor
+     */
+    Enactor() :
+        BaseEnactor("sssp"),
+        problem    (NULL  )
+    {
+        this -> max_num_vertex_associates
+            = (Problem::FLAG & Mark_Predecessors) != 0 ? 1 : 0;
+        this -> max_num_value__associates = 1;
+    }
+
+    /**
+     * @brief SSSPEnactor destructor
+     */
+    virtual ~Enactor()
+    {
+        //Release();
+    }
+
+    /*
+     * @brief Releasing allocated memory space
+     * @param target The location to release memory from
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Release(util::Location target = util::LOCATION_ALL)
+    {
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseEnactor::Release(target));
+        delete []iterations; iterations = NULL;
+        problem = NULL;
+        return retval;
+    }
+
+    /**
+     * @brief Initialize the enactor.
+     * @param[in] problem The problem object.
+     * @param[in] target Target location of data
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Init(
+        Problem          &problem,
+        util::Location    target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        this->problem = &problem;
+
+        GUARD_CU(BaseEnactor::Init(
+            problem, Enactor_None, 2, NULL, target, false));
+        for (int gpu = 0; gpu < this -> num_gpus; gpu ++)
+        {
+            GUARD_CU(util::SetDevice(this -> gpu_idx[gpu]));
+            auto &enactor_slice
+                = this -> enactor_slices[gpu * this -> num_gpus + 0];
+            auto &graph = problem.sub_graphs[gpu];
+            GUARD_CU(enactor_slice.frontier.Allocate(
+                graph.nodes, graph.edges, this -> queue_factors));
+
+            for (int peer = 0; peer < this -> num_gpus; peer ++)
+            {
+                this -> enactor_slices[gpu * this -> num_gpus + peer]
+                    .oprtr_parameters.labels
+                    = &(problem.data_slices[gpu] -> labels);
+            }
+        }
+
+        iterations = new IterationT[this -> num_gpus];
+        for (int gpu = 0; gpu < this -> num_gpus; gpu ++)
+        {
+            GUARD_CU(iterations[gpu].Init(this, gpu));
+        }
+
+        GUARD_CU(this -> Init_Threads(this,
+            (CUT_THREADROUTINE)&(GunrockThread<EnactorT>)));
+        return retval;
+    }
+
+    /**
+     * @brief Reset enactor
+     * @param[in] src Source node to start primitive.
+     * @param[in] target Target location of data
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Reset(VertexT src, util::Location target = util::DEVICE)
+    {
+        typedef typename GraphT::GpT GpT;
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseEnactor::Reset(target));
+        for (int gpu = 0; gpu < this->num_gpus; gpu++)
+        {
+            if ((this->num_gpus == 1) ||
+                (gpu == this->problem->org_graph->GpT::partition_table[src]))
+            {
+                this -> thread_slices[gpu].init_size = 1;
+                for (int peer_ = 0; peer_ < this -> num_gpus; peer_++)
+                {
+                    auto &frontier = this ->
+                        enactor_slices[gpu * this -> num_gpus + peer_].frontier;
+                    frontier.queue_length = (peer_ == 0) ? 1 : 0;
+                    if (peer_ == 0)
+                    {
+                        GUARD_CU(frontier.V_Q() -> ForEach(
+                            [src]__host__ __device__ (VertexT &v)
+                        {
+                            v = src;
+                        }, 1, target, 0));
+                    }
+                }
+            }
+
+            else {
+                this -> thread_slices[gpu].init_size = 0;
+                for (int peer_ = 0; peer_ < this -> num_gpus; peer_++)
+                {
+                    this -> enactor_slices[gpu * this -> num_gpus + peer_]
+                        .frontier.queue_length = 0;
+                }
+            }
+        }
+        GUARD_CU(BaseEnactor::Sync());
+        return retval;
+    }
+
+    /**
+      * @brief one run of sssp, to be called within GunrockThread
+      * @param thread_data Data for the CPU thread
+      * \return cudaError_t error message(s), if any
+      */
+    cudaError_t Run(ThreadSlice &thread_data)
+    {
+        gunrock::app::Iteration_Loop<
+            ((Enactor::Problem::FLAG & Mark_Predecessors) != 0) ? 1 : 0,
+            1, IterationT>(
+            thread_data, iterations[thread_data.thread_num]);
+        return cudaSuccess;
+    }
+
+    /**
+     * @brief Enacts a SSSP computing on the specified graph.
+     * @param[in] src Source node to start primitive.
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Enact(VertexT src)
+    {
+        cudaError_t  retval     = cudaSuccess;
+        GUARD_CU(this -> Run_Threads(this));
+        util::PrintMsg("GPU SSSP Done.", this -> flag & Debug);
+        return retval;
+    }
+
+    /** @} */
+};
+
+} // namespace sssp
+} // namespace app
+} // namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/gunrock/app/vn/vn_problem.cuh
+++ b/gunrock/app/vn/vn_problem.cuh
@@ -1,0 +1,462 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * sssp_problem.cuh
+ *
+ * @brief GPU Storage management Structure for SSSP Problem Data
+ */
+
+#pragma once
+
+#include <gunrock/app/problem_base.cuh>
+
+namespace gunrock {
+namespace app {
+namespace sssp {
+
+/**
+ * @brief Speciflying parameters for SSSP Problem
+ * @param  parameters  The util::Parameter<...> structure holding all parameter info
+ * \return cudaError_t error message(s), if any
+ */
+cudaError_t UseParameters_problem(
+    util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+
+    GUARD_CU(gunrock::app::UseParameters_problem(parameters));
+    GUARD_CU(parameters.Use<bool>(
+        "mark-pred",
+        util::OPTIONAL_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
+        false,
+        "Whether to mark predecessor info.",
+        __FILE__, __LINE__));
+
+    return retval;
+}
+
+/**
+ * @brief Single-Source Shortest Path Problem structure.
+ * @tparam _GraphT  Type of the graph
+ * @tparam _LabelT  Type of labels used in sssp
+ * @tparam _ValueT  Type of per-vertex distance values
+ * @tparam _FLAG    Problem flags
+ */
+template <
+    typename _GraphT,
+    typename _LabelT = typename _GraphT::VertexT,
+    typename _ValueT = typename _GraphT::ValueT,
+    ProblemFlag _FLAG = Problem_None>
+struct Problem : ProblemBase<_GraphT, _FLAG>
+{
+    typedef _GraphT GraphT;
+    static const ProblemFlag FLAG = _FLAG;
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef typename GraphT::CsrT    CsrT;
+    typedef typename GraphT::GpT     GpT;
+    typedef          _LabelT         LabelT;
+    typedef          _ValueT         ValueT;
+
+    typedef ProblemBase   <GraphT, FLAG> BaseProblem;
+    typedef DataSliceBase <GraphT, FLAG> BaseDataSlice;
+
+    //Helper structures
+
+    /**
+     * @brief Data structure containing SSSP-specific data on indivual GPU.
+     */
+    struct DataSlice : BaseDataSlice
+    {
+        // sssp-specific storage arrays
+        util::Array1D<SizeT, ValueT >    distances  ; // source distance
+        util::Array1D<SizeT, LabelT >    labels     ; // labels to mark latest iteration the vertex been visited
+        util::Array1D<SizeT, VertexT>    preds      ; // predecessors of vertices
+        util::Array1D<SizeT, VertexT>    temp_preds ; // predecessors of vertices
+
+        /*
+         * @brief Default constructor
+         */
+        DataSlice() : BaseDataSlice()
+        {
+            distances       .SetName("distances"       );
+            labels          .SetName("labels"          );
+            preds           .SetName("preds"           );
+            temp_preds      .SetName("temp_preds"      );
+        }
+
+        /*
+         * @brief Default destructor
+         */
+        virtual ~DataSlice()
+        {
+            Release();
+        }
+
+        /*
+         * @brief Releasing allocated memory space
+         * @param[in] target      The location to release memory from
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Release(util::Location target = util::LOCATION_ALL)
+        {
+            cudaError_t retval = cudaSuccess;
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx));
+
+            GUARD_CU(distances      .Release(target));
+            GUARD_CU(labels         .Release(target));
+            GUARD_CU(preds          .Release(target));
+            GUARD_CU(temp_preds     .Release(target));
+            GUARD_CU(BaseDataSlice ::Release(target));
+            return retval;
+        }
+
+        /**
+         * @brief initializing sssp-specific data on each gpu
+         * @param     sub_graph   Sub graph on the GPU.
+         * @param[in] num_gpus    Number of GPUs
+         * @param[in] gpu_idx     GPU device index
+         * @param[in] target      Targeting device location
+         * @param[in] flag        Problem flag containling options
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Init(
+            GraphT        &sub_graph,
+            int            num_gpus = 1,
+            int            gpu_idx = 0,
+            util::Location target  = util::DEVICE,
+            ProblemFlag    flag    = Problem_None)
+        {
+            cudaError_t retval  = cudaSuccess;
+
+            GUARD_CU(BaseDataSlice::Init(
+                sub_graph, num_gpus, gpu_idx, target, flag));
+            GUARD_CU(distances .Allocate(sub_graph.nodes, target));
+            GUARD_CU(labels    .Allocate(sub_graph.nodes, target));
+            if (flag & Mark_Predecessors)
+            {
+                GUARD_CU(preds      .Allocate(sub_graph.nodes, target));
+                GUARD_CU(temp_preds .Allocate(sub_graph.nodes, target));
+            }
+
+            /*if (target & util::DEVICE)
+            {
+                GUARD_CU(sub_graph.CsrT::Move(util::HOST, target, this -> stream));
+            }*/
+            GUARD_CU(sub_graph.Move(util::HOST, target, this -> stream));
+            return retval;
+        } // Init
+
+        /**
+         * @brief Reset problem function. Must be called prior to each run.
+         * @param[in] target      Targeting device location
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Reset(util::Location target = util::DEVICE)
+        {
+            cudaError_t retval = cudaSuccess;
+            SizeT nodes = this -> sub_graph -> nodes;
+
+            // Ensure data are allocated
+            GUARD_CU(distances.EnsureSize_(nodes, target));
+            GUARD_CU(labels   .EnsureSize_(nodes, target));
+            if (this -> flag & Mark_Predecessors)
+            {
+                GUARD_CU(preds.EnsureSize_(nodes, target));
+                GUARD_CU(temp_preds.EnsureSize_(nodes, target));
+            }
+
+            // Reset data
+            GUARD_CU(distances.ForEach([]__host__ __device__
+            (ValueT &distance){
+                distance = util::PreDefinedValues<ValueT>::MaxValue;
+            }, nodes, target, this -> stream));
+
+            GUARD_CU(labels   .ForEach([]__host__ __device__
+            (LabelT &label){
+                label = util::PreDefinedValues<LabelT>::InvalidValue;
+            }, nodes, target, this -> stream));
+
+            if (this -> flag & Mark_Predecessors)
+            {
+                GUARD_CU(preds.ForAll([]__host__ __device__
+                (VertexT *preds_, const SizeT &pos){
+                    preds_[pos] = pos;
+                }, nodes, target, this -> stream));
+
+                GUARD_CU(temp_preds.ForAll([]__host__ __device__
+                (VertexT *preds_, const SizeT &pos){
+                    preds_[pos] = pos;
+                }, nodes, target, this -> stream));
+            }
+
+            return retval;
+        }
+    }; // DataSlice
+
+    // Members
+    // Set of data slices (one for each GPU)
+    util::Array1D<SizeT, DataSlice> *data_slices;
+
+    // Methods
+
+    /**
+     * @brief SSSPProblem default constructor
+     */
+    Problem(
+        util::Parameters &_parameters,
+        ProblemFlag _flag = Problem_None) :
+        BaseProblem(_parameters, _flag),
+        data_slices(NULL)
+    {
+    }
+
+    /**
+     * @brief SSSPProblem default destructor
+     */
+    virtual ~Problem()
+    {
+        Release();
+    }
+
+    /*
+     * @brief Releasing allocated memory space
+     * @param[in] target      The location to release memory from
+     * \return    cudaError_t Error message(s), if any
+     */
+    cudaError_t Release(util::Location target = util::LOCATION_ALL)
+    {
+        cudaError_t retval = cudaSuccess;
+        if (data_slices == NULL) return retval;
+        for (int i = 0; i < this->num_gpus; i++)
+            GUARD_CU(data_slices[i].Release(target));
+
+        if ((target & util::HOST) != 0 &&
+            data_slices[0].GetPointer(util::DEVICE) == NULL)
+        {
+            delete[] data_slices; data_slices=NULL;
+        }
+        GUARD_CU(BaseProblem::Release(target));
+        return retval;
+    }
+
+    /**
+     * \addtogroup PublicInterface
+     * @{
+     */
+
+    /**
+     * @brief Copy result distancess computed on GPUs back to host-side arrays.
+     * @param[out] h_distances Host array to store computed vertex distances from the source.
+     * @param[out] h_preds     Host array to store computed vertex predecessors.
+     * @param[in]  target where the results are stored
+     * \return     cudaError_t Error message(s), if any
+     */
+    cudaError_t Extract(
+        ValueT         *h_distances,
+        VertexT        *h_preds     = NULL,
+        util::Location  target      = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        SizeT nodes = this -> org_graph -> nodes;
+
+        if (this-> num_gpus == 1)
+        {
+            auto &data_slice = data_slices[0][0];
+
+            // Set device
+            if (target == util::DEVICE)
+            {
+                GUARD_CU(util::SetDevice(this->gpu_idx[0]));
+
+                GUARD_CU(data_slice.distances.SetPointer(
+                    h_distances, nodes, util::HOST));
+                GUARD_CU(data_slice.distances.Move(util::DEVICE, util::HOST));
+
+                if ((this -> flag & Mark_Predecessors) == 0)
+                    return retval;
+                GUARD_CU(data_slice.preds.SetPointer(h_preds, nodes, util::HOST));
+                GUARD_CU(data_slice.preds.Move(util::DEVICE, util::HOST));
+            }
+            else if (target == util::HOST) {
+                GUARD_CU(data_slice.distances.ForEach(h_distances,
+                    []__host__ __device__
+                    (const ValueT &distance, ValueT &h_distance){
+                        h_distance = distance;
+                    }, nodes, util::HOST));
+
+                if (this -> flag & Mark_Predecessors)
+                    GUARD_CU(data_slice.preds.ForEach(h_preds,
+                    []__host__ __device__
+                    (const VertexT &pred, VertexT &h_pred){
+                        h_pred = pred;
+                    }, nodes, util::HOST));
+            }
+        }
+        else { // num_gpus != 1
+            util::Array1D<SizeT, ValueT *> th_distances;
+            util::Array1D<SizeT, VertexT*> th_preds;
+            th_distances.SetName("bfs::Problem::Extract::th_distances");
+            th_preds    .SetName("bfs::Problem::Extract::th_preds");
+            GUARD_CU(th_distances.Allocate(this->num_gpus, util::HOST));
+            GUARD_CU(th_preds    .Allocate(this->num_gpus, util::HOST));
+
+            for (int gpu = 0; gpu < this->num_gpus; gpu++)
+            {
+                auto &data_slice = data_slices[gpu][0];
+                if (target == util::DEVICE)
+                {
+                    GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+                    GUARD_CU(data_slice.distances.Move(util::DEVICE, util::HOST));
+                    if (this -> flag & Mark_Predecessors)
+                        GUARD_CU(data_slice.preds.Move(util::DEVICE, util::HOST));
+                }
+                th_distances[gpu] = data_slice.distances.GetPointer(util::HOST);
+                th_preds    [gpu] = data_slice.preds    .GetPointer(util::HOST);
+            } //end for(gpu)
+
+            for (VertexT v = 0; v < nodes; v++)
+            {
+                int gpu = this -> org_graph -> GpT::partition_table[v];
+                VertexT v_ = v;
+                if ((GraphT::FLAG & gunrock::partitioner::Keep_Node_Num) != 0)
+                    v_ = this -> org_graph -> GpT::convertion_table[v];
+
+                h_distances[v] = th_distances[gpu][v_];
+                if (this -> flag & Mark_Predecessors)
+                    h_preds[v] = th_preds    [gpu][v_];
+            }
+
+            GUARD_CU(th_distances.Release());
+            GUARD_CU(th_preds    .Release());
+        } //end if
+
+        return retval;
+    }
+
+    /**
+     * @brief initialization function.
+     * @param     graph       The graph that SSSP processes on
+     * @param[in] Location    Memory location to work on
+     * \return    cudaError_t Error message(s), if any
+     */
+    cudaError_t Init(
+        GraphT           &graph,
+        util::Location    target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseProblem::Init(graph, target));
+        data_slices = new util::Array1D<SizeT, DataSlice>[this->num_gpus];
+
+        if (this -> parameters.template Get<bool>("mark-pred"))
+            this -> flag = this -> flag | Mark_Predecessors;
+
+        for (int gpu = 0; gpu < this->num_gpus; gpu++)
+        {
+            data_slices[gpu].SetName("data_slices[" + std::to_string(gpu) + "]");
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+
+            GUARD_CU(data_slices[gpu].Allocate(1, target | util::HOST));
+
+            auto &data_slice = data_slices[gpu][0];
+            GUARD_CU(data_slice.Init(this -> sub_graphs[gpu],
+                this -> num_gpus, this -> gpu_idx[gpu], target, this -> flag));
+        } // end for (gpu)
+
+        return retval;
+    }
+
+    /**
+     * @brief Reset problem function. Must be called prior to each run.
+     * @param[in] src      Source vertex to start.
+     * @param[in] location Memory location to work on
+     * \return cudaError_t Error message(s), if any
+     */
+    cudaError_t Reset(
+        VertexT    src,
+        util::Location target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+
+        for (int gpu = 0; gpu < this->num_gpus; ++gpu)
+        {
+            // Set device
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+            GUARD_CU(data_slices[gpu] -> Reset(target));
+            GUARD_CU(data_slices[gpu].Move(util::HOST, target));
+        }
+
+        // Fillin the initial input_queue for SSSP problem
+        int gpu;
+        VertexT src_;
+        if (this->num_gpus <= 1)
+        {
+            gpu = 0; src_=src;
+        } else {
+            gpu = this -> org_graph -> partition_table[src];
+            if (this -> flag & partitioner::Keep_Node_Num)
+                src_ = src;
+            else
+                src_ = this -> org_graph -> GpT::convertion_table[src];
+        }
+        if (target & util::DEVICE)
+        {
+            GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+            GUARD_CU2(cudaDeviceSynchronize(),
+                "cudaDeviceSynchronize failed");
+        }
+
+        ValueT src_distance = 0;
+        if (target & util::HOST)
+        {
+            data_slices[gpu] -> distances[src_] = src_distance;
+            if (this -> flag & Mark_Predecessors)
+                data_slices[gpu] -> preds[src_]
+                    = util::PreDefinedValues<VertexT>::InvalidValue;
+        }
+
+        if (target & util::DEVICE)
+        {
+            GUARD_CU2(cudaMemcpy(
+                data_slices[gpu]->distances.GetPointer(util::DEVICE) + src_,
+                &src_distance, sizeof(ValueT),
+                cudaMemcpyHostToDevice),
+                "SSSPProblem cudaMemcpy distances failed");
+
+            if (this -> flag & Mark_Predecessors)
+            {
+                VertexT src_pred = util::PreDefinedValues<VertexT>::InvalidValue;
+                GUARD_CU2(cudaMemcpy(
+                    data_slices[gpu]->preds.GetPointer(util::DEVICE) + src_,
+                    &src_pred, sizeof(VertexT),
+                    cudaMemcpyHostToDevice),
+                    "SSSPProblem cudaMemcpy preds failed");
+            }
+            GUARD_CU2(cudaDeviceSynchronize(),
+                "cudaDeviceSynchronize failed");
+        }
+
+        return retval;
+    }
+
+    /** @} */
+};
+
+} //namespace sssp
+} //namespace app
+} //namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/gunrock/app/vn/vn_test.cuh
+++ b/gunrock/app/vn/vn_test.cuh
@@ -1,0 +1,436 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * sssp_test.cu
+ *
+ * @brief Test related functions for SSSP
+ */
+
+#pragma once
+
+#ifdef BOOST_FOUND
+    // Boost includes for CPU Dijkstra SSSP reference algorithms
+    #include <boost/config.hpp>
+    #include <boost/graph/graph_traits.hpp>
+    #include <boost/graph/adjacency_list.hpp>
+    #include <boost/graph/dijkstra_shortest_paths.hpp>
+    #include <boost/property_map/property_map.hpp>
+#else
+    #include <queue>
+    #include <vector>
+    #include <utility>
+#endif
+
+namespace gunrock {
+namespace app {
+namespace sssp {
+
+/******************************************************************************
+ * Housekeeping Routines
+ ******************************************************************************/
+
+/**
+ * @brief Displays the SSSP result (i.e., distance from source)
+ * @tparam T Type of values to display
+ * @tparam SizeT Type of size counters
+ * @param[in] preds Search depth from the source for each node.
+ * @param[in] num_nodes Number of nodes in the graph.
+ */
+template<typename T, typename SizeT>
+void DisplaySolution(T *array, SizeT length)
+{
+    if (length > 40)
+        length = 40;
+
+    util::PrintMsg("[", true, false);
+    for (SizeT i = 0; i < length; ++i)
+    {
+        util::PrintMsg(std::to_string(i) + ":"
+            + std::to_string(array[i]) + " ", true, false);
+    }
+    util::PrintMsg("]");
+}
+
+/******************************************************************************
+ * SSSP Testing Routines
+ *****************************************************************************/
+
+/**
+ * @brief Simple CPU-based reference SSSP implementations
+ * @tparam      GraphT        Type of the graph
+ * @tparam      ValueT        Type of the distances
+ * @param[in]   graph         Input graph
+ * @param[out]  distances     Computed distances from the source to each vertex
+ * @param[out]  preds         Computed predecessors for each vertex
+ * @param[in]   src           The source vertex
+ * @param[in]   quiet         Whether to print out anything to stdout
+ * @param[in]   mark_preds    Whether to compute predecessor info
+ * \return      double        Time taken for the SSSP
+ */
+template <
+    typename GraphT,
+    typename ValueT = typename GraphT::ValueT>
+double CPU_Reference(
+    const    GraphT          &graph,
+                     ValueT  *distances,
+    typename GraphT::VertexT *preds,
+    typename GraphT::VertexT  src,
+    bool                      quiet,
+    bool                      mark_preds)
+{
+#ifdef BOOST_FOUND
+    using namespace boost;
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef typename GraphT::ValueT  GValueT;
+    typedef typename GraphT::CsrT    CsrT;
+
+    // Prepare Boost Datatype and Data structure
+    typedef adjacency_list<vecS, vecS, directedS, no_property,
+            property <edge_weight_t, GValueT> > BGraphT;
+
+    typedef typename graph_traits<BGraphT>::vertex_descriptor vertex_descriptor;
+    typedef typename graph_traits<BGraphT>::edge_descriptor edge_descriptor;
+
+    typedef std::pair<VertexT, VertexT> EdgeT;
+
+    EdgeT   *edges = ( EdgeT*)malloc(sizeof( EdgeT) * graph.edges);
+    GValueT *weight = (GValueT*)malloc(sizeof(GValueT) * graph.edges);
+
+    for (VertexT v = 0; v < graph.nodes; ++v)
+    {
+        SizeT edge_start = graph.CsrT::GetNeighborListOffset(v);
+        SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+        for (SizeT e = 0; e < num_neighbors; ++e)
+        {
+            edges [e + edge_start] = EdgeT(v, graph.CsrT::GetEdgeDest(e + edge_start));
+            weight[e + edge_start] = graph.CsrT::edge_values[e + edge_start];
+        }
+    }
+
+    BGraphT g(edges, edges + graph.edges, weight, graph.nodes);
+
+    std::vector<ValueT>            d(graph.nodes);
+    std::vector<vertex_descriptor> p(graph.nodes);
+    vertex_descriptor s = vertex(src, g);
+
+    typename property_map<BGraphT, vertex_index_t>::type
+        indexmap = get(vertex_index, g);
+
+    //
+    // Perform SSSP
+    //
+
+    util::CpuTimer cpu_timer;
+    cpu_timer.Start();
+
+    if (mark_preds)
+    {
+        dijkstra_shortest_paths(g, s,
+            predecessor_map(boost::make_iterator_property_map(
+                p.begin(), get(boost::vertex_index, g))).distance_map(
+                    boost::make_iterator_property_map(
+                        d.begin(), get(boost::vertex_index, g))));
+    }
+    else
+    {
+        dijkstra_shortest_paths(g, s,
+            distance_map(boost::make_iterator_property_map(
+                d.begin(), get(boost::vertex_index, g))));
+    }
+    cpu_timer.Stop();
+    float elapsed = cpu_timer.ElapsedMillis();
+
+    //util::PrintMsg("CPU SSSP finished in " + std::to_string(elapsed)
+    //    + " msec.", !quiet);
+
+    typedef std::pair<VertexT, ValueT> PairT;
+    PairT* sort_dist = new PairT[graph.nodes];
+    typename graph_traits <BGraphT>::vertex_iterator vi, vend;
+    for (tie(vi, vend) = vertices(g); vi != vend; ++vi)
+    {
+        sort_dist[(*vi)].first  = (*vi);
+        sort_dist[(*vi)].second = d[(*vi)];
+    }
+    std::stable_sort(
+        sort_dist, sort_dist + graph.nodes,
+        //RowFirstTupleCompare<Coo<Value, Value> >);
+        [](const PairT &a, const PairT &b) -> bool
+        {
+            return a.first < b.first;
+        });
+    for (VertexT v = 0; v < graph.nodes; ++v)
+        distances[v] = sort_dist[v].second;
+    delete[] sort_dist; sort_dist = NULL;
+
+    if (mark_preds)
+    {
+        typedef std::pair<VertexT, VertexT> VPairT;
+        VPairT* sort_pred = new VPairT[graph.nodes];
+        for (tie(vi, vend) = vertices(g); vi != vend; ++vi)
+        {
+            sort_pred[(*vi)].first  = (*vi);
+            sort_pred[(*vi)].second = p[(*vi)];
+        }
+        std::stable_sort(
+            sort_pred, sort_pred + graph.nodes,
+            //RowFirstTupleCompare< Coo<VertexId, VertexId> >);
+            [](const VPairT &a, const VPairT &b) -> bool
+            {
+                return a.first < b.first;
+            });
+        for (VertexT v = 0; v < graph.nodes; ++v)
+            preds[v] = sort_pred[v].second;
+        delete[] sort_pred; sort_pred = NULL;
+    }
+
+    return elapsed;
+#else
+
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef std::pair<VertexT, ValueT> PairT;
+    struct GreaterT
+    {
+        bool operator()(const PairT& lhs, const PairT& rhs)
+        {
+            return lhs.second > rhs.second;
+        }
+    };
+    typedef std::priority_queue<PairT, std::vector<PairT>, GreaterT> PqT;
+
+    for (VertexT v = 0; v < graph.nodes; v++)
+    {
+        distances[v] = util::PreDefinedValues<ValueT>::MaxValue;
+        if (mark_preds && preds != NULL)
+            preds[v] = util::PreDefinedValues<VertexT>::InvalidValue;
+    }
+    distances[src] = 0;
+    if (mark_preds && preds != NULL)
+        preds[src] = src;
+
+    PqT pq;
+    pq.push(std::make_pair(src, 0));
+    util::CpuTimer cpu_timer;
+    cpu_timer.Start();
+    while (!pq.empty())
+    {
+        auto pair = pq.top();
+        pq.pop();
+        VertexT v = pair.first;
+        ValueT v_distance = pair.second;
+        if (v_distance > distances[v])
+            continue;
+
+        SizeT e_start = graph.GetNeighborListOffset(v);
+        SizeT e_end = e_start + graph.GetNeighborListLength(v);
+        for (SizeT e = e_start; e < e_end; e++)
+        {
+            VertexT u = graph.GetEdgeDest(e);
+            ValueT u_distance = v_distance + graph.edge_values[e];
+            if (u_distance < distances[u])
+            {
+                distances[u] = u_distance;
+                if (mark_preds && preds != NULL)
+                    preds[u] = v;
+                pq.push(std::make_pair(u, u_distance));
+            }
+        }
+    }
+    cpu_timer.Stop();
+    float elapsed = cpu_timer.ElapsedMillis();
+    //util::PrintMsg("CPU SSSP finished in " + std::to_string(elapsed)
+    //    + " msec.", !quiet);
+
+    return elapsed;
+#endif
+}
+
+/**
+ * @brief Validation of SSSP results
+ * @tparam     GraphT        Type of the graph
+ * @tparam     ValueT        Type of the distances
+ * @param[in]  parameters    Excution parameters
+ * @param[in]  graph         Input graph
+ * @param[in]  src           The source vertex
+ * @param[in]  h_distances   Computed distances from the source to each vertex
+ * @param[in]  h_preds       Computed predecessors for each vertex
+ * @param[in]  ref_distances Reference distances from the source to each vertex
+ * @param[in]  ref_preds     Reference predecessors for each vertex
+ * @param[in]  verbose       Whether to output detail comparsions
+ * \return     GraphT::SizeT Number of errors
+ */
+template <
+    typename GraphT,
+    typename ValueT = typename GraphT::ValueT>
+typename GraphT::SizeT Validate_Results(
+             util::Parameters &parameters,
+             GraphT           &graph,
+    typename GraphT::VertexT   src,
+                     ValueT   *h_distances,
+    typename GraphT::VertexT  *h_preds,
+                     ValueT   *ref_distances = NULL,
+    typename GraphT::VertexT  *ref_preds     = NULL,
+                     bool      verbose       = true)
+{
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef typename GraphT::CsrT    CsrT;
+
+    SizeT num_errors = 0;
+    //bool quick = parameters.Get<bool>("quick");
+    bool quiet = parameters.Get<bool>("quiet");
+    bool mark_pred = parameters.Get<bool>("mark-pred");
+
+    // Verify the result
+    if (ref_distances != NULL)
+    {
+        for (VertexT v = 0; v < graph.nodes; v++)
+        {
+            if (!util::isValid(ref_distances[v]))
+                ref_distances[v] = util::PreDefinedValues<ValueT>::MaxValue;
+        }
+
+        util::PrintMsg("Distance Validity: ", !quiet, false);
+        SizeT errors_num = util::CompareResults(
+            h_distances, ref_distances,
+            graph.nodes, true, quiet);
+        if (errors_num > 0)
+        {
+            util::PrintMsg(
+                std::to_string(errors_num) + " errors occurred.", !quiet);
+            num_errors += errors_num;
+        }
+    }
+    else if (ref_distances == NULL)
+    {
+        util::PrintMsg("Distance Validity: ", !quiet, false);
+        SizeT errors_num = 0;
+        for (VertexT v = 0; v < graph.nodes; v++)
+        {
+            ValueT v_distance = h_distances[v];
+            if (!util::isValid(v_distance))
+                continue;
+            SizeT e_start = graph.CsrT::GetNeighborListOffset(v);
+            SizeT num_neighbors = graph.CsrT::GetNeighborListLength(v);
+            SizeT e_end = e_start + num_neighbors;
+            for (SizeT e = e_start; e < e_end; e++)
+            {
+                VertexT u = graph.CsrT::GetEdgeDest(e);
+                ValueT u_distance = h_distances[u];
+                ValueT e_value = graph.CsrT::edge_values[e];
+                if (v_distance + e_value >= u_distance)
+                    continue;
+                errors_num ++;
+                if (errors_num > 1)
+                    continue;
+
+                util::PrintMsg("FAIL: v[" + std::to_string(v)
+                    + "] ("    + std::to_string(v_distance)
+                    + ") + e[" + std::to_string(e)
+                    + "] ("    + std::to_string(e_value)
+                    + ") < u[" + std::to_string(u)
+                    + "] ("    + std::to_string(u_distance) + ")", !quiet);
+            }
+        }
+        if (errors_num > 0)
+        {
+            util::PrintMsg(std::to_string(errors_num) + " errors occurred.", !quiet);
+            num_errors += errors_num;
+        } else {
+            util::PrintMsg("PASS", !quiet);
+        }
+    }
+
+    if (!quiet && verbose)
+    {
+        // Display Solution
+        util::PrintMsg("First 40 distances of the GPU result:");
+        DisplaySolution(h_distances, graph.nodes);
+        if (ref_distances != NULL)
+        {
+            util::PrintMsg("First 40 distances of the reference CPU result.");
+            DisplaySolution(ref_distances, graph.nodes);
+        }
+        util::PrintMsg("");
+    }
+
+    if (mark_pred)
+    {
+        util::PrintMsg("Predecessors Validity: ", !quiet, false);
+        SizeT errors_num = 0;
+        for (VertexT v = 0; v < graph.nodes; v++)
+        {
+            VertexT pred          = h_preds[v];
+            if (!util::isValid(pred) || v == src)
+                continue;
+            ValueT  v_distance    = h_distances[v];
+            if (v_distance == util::PreDefinedValues<ValueT>::MaxValue)
+                continue;
+            ValueT  pred_distance = h_distances[pred];
+            bool edge_found = false;
+            SizeT edge_start = graph.CsrT::GetNeighborListOffset(pred);
+            SizeT num_neighbors = graph.CsrT::GetNeighborListLength(pred);
+
+            for (SizeT e = edge_start; e < edge_start + num_neighbors; e++)
+            {
+                if (v == graph.CsrT::GetEdgeDest(e) &&
+                    std::abs((pred_distance + graph.CsrT::edge_values[e]
+                    - v_distance) * 1.0) < 1e-6)
+                {
+                    edge_found = true;
+                    break;
+                }
+            }
+            if (edge_found)
+                continue;
+            errors_num ++;
+            if (errors_num > 1)
+                continue;
+
+            util::PrintMsg("FAIL: [" + std::to_string(pred)
+                + "] ("    + std::to_string(pred_distance)
+                + ") -> [" + std::to_string(v)
+                + "] ("    + std::to_string(v_distance)
+                + ") can't find the corresponding edge.", !quiet);
+        }
+        if (errors_num > 0)
+        {
+            util::PrintMsg(std::to_string(errors_num) + " errors occurred.", !quiet);
+            num_errors += errors_num;
+        } else {
+            util::PrintMsg("PASS", !quiet);
+        }
+    }
+
+    if (!quiet && mark_pred && verbose)
+    {
+        util::PrintMsg("First 40 preds of the GPU result:");
+        DisplaySolution(h_preds, graph.nodes);
+        if (ref_preds != NULL)
+        {
+            util::PrintMsg("First 40 preds of the reference CPU result "
+                "(could be different because the paths are not unique):");
+            DisplaySolution(ref_preds, graph.nodes);
+        }
+        util::PrintMsg("");
+    }
+
+    return num_errors;
+}
+
+} // namespace sssp
+} // namespace app
+} // namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/tests/vn/Makefile
+++ b/tests/vn/Makefile
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------
+# Gunrock -- Fast and Efficient GPU Graph Library
+# ----------------------------------------------------------------
+# This source code is distributed under the terms of LICENSE.TXT
+# in the root directory of this source distribution.
+# ----------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# (make test) Test driver for ALGO
+#-------------------------------------------------------------------------------
+
+include ../BaseMakefile.mk
+ALGO = sssp
+EXEC = bin/test_$(ALGO)_$(NVCC_VERSION)_$(ARCH_SUFFIX)
+
+test: $(EXEC)
+
+$(EXEC) : test_$(ALGO).cu $(DEPS)
+	mkdir -p bin
+	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
+
+a : test_$(ALGO).cu $(DEPS)
+	mkdir -p bin
+	rm -f $(EXEC)
+	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3 > a.txt 2>&1 || true
+	grep rror: a.txt; grep arn a.txt
+
+.DEFAULT_GOAL := test

--- a/tests/vn/Makefile
+++ b/tests/vn/Makefile
@@ -10,14 +10,14 @@
 #-------------------------------------------------------------------------------
 
 include ../BaseMakefile.mk
-ALGO = sssp
+ALGO = vn
 EXEC = bin/test_$(ALGO)_$(NVCC_VERSION)_$(ARCH_SUFFIX)
 
 test: $(EXEC)
 
 $(EXEC) : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
-	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
+	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
 
 a : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin

--- a/tests/vn/make_summary.cpp
+++ b/tests/vn/make_summary.cpp
@@ -1,0 +1,329 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+using namespace std;
+
+class SummaryItem
+{
+public: 
+    string name;
+    int num_search_tokens, num_record_tokens, offset;
+    string* search_tokens;
+    string* record_tokens;
+
+    SummaryItem() :
+        name(""),
+        num_search_tokens(0),
+        num_record_tokens(0),
+        offset(0),
+        search_tokens(NULL),
+        record_tokens(NULL)
+    {
+    }
+
+    void Init(
+        const char name[],
+        int num_search_tokens,
+        string* search_tokens,
+        int offset,
+        int num_record_tokens)
+    {
+        this->name = string(name);
+        this->num_search_tokens = num_search_tokens;
+        this->num_record_tokens = num_record_tokens;
+        if (num_search_tokens !=0) 
+        {
+            this->search_tokens = new string[num_search_tokens];
+            for (int i=0; i<num_search_tokens; i++)
+                this->search_tokens[i] = search_tokens[i];
+        }
+        this->record_tokens = new string[num_record_tokens == 0? 1: num_record_tokens];
+        this->offset = offset;
+        Reset();
+    }
+
+    ~SummaryItem()
+    {
+        if (search_tokens != NULL) {delete[] search_tokens; search_tokens= NULL;}
+        if (record_tokens != NULL) {delete[] record_tokens; record_tokens= NULL;}
+    }
+
+    void Reset()
+    {
+        for (int i=0; i<num_record_tokens; i++)
+            record_tokens[i] = "";
+        if (num_record_tokens==0) record_tokens[0] = "false_";
+    }
+};
+
+bool isSeparator(char ch, int num_separators, char* separators)
+{
+    for (int i=0; i< num_separators; i++)
+        if (ch == separators[i]) return true;
+    return false;
+}
+
+string GetNextToken(ifstream *fin, int num_separators, char* separators)
+{
+    string str="";
+
+    char ch = ' ';
+    fin->get(ch);
+    while (isSeparator(ch, num_separators, separators) && !fin->eof())
+        fin->get(ch);
+
+    while (!isSeparator(ch, num_separators, separators) && !fin->eof())
+    {
+        str=str+ch;
+        fin->get(ch);
+    }
+    return str;
+}
+
+bool TokensMatch(string *current_tokens, int offset, string *search_tokens, int num_search_tokens)
+{
+    if (num_search_tokens == 0) return false;
+    for (int i=0; i<num_search_tokens; i++)
+        if (search_tokens[i] != current_tokens[offset + i]) return false;
+    return true;
+}
+
+int GetSubstringPos(string org_str, string sub_str)
+{
+    for (int i=0; i< (signed)(org_str.length() - sub_str.length() + 1); i++)
+    {
+        bool is_same = true;
+        for (unsigned int j=0; j< sub_str.length(); j++)
+        if (org_str[i + j] != sub_str[j]) 
+        {
+            is_same = false; break;
+        }
+        if (is_same) return i;
+    }
+    return -1;
+}
+
+int main(int argc, char* argv[])
+{
+    DIR *directory;
+    struct dirent *dir_item;
+    struct stat filestat;
+    int num_items = 27;
+    SummaryItem *items = new SummaryItem[27];
+    string search_tokens[5];
+    string *current_tokens = NULL;
+    char seperators[] = {' ', '\0', '\13', '\t', '\n', ':', '[', ']',',', ')', '('};
+    int num_seperators = 11;
+    int max_length = 0;
+    int num_tokens = 0;
+    string** token_lists = new string*[1024];
+    for (int i=0; i<1024; i++) token_lists[i] = NULL;
+    ofstream fout;
+    
+    items[ 0].Init("test_name", 0, search_tokens,  0, 1);
+    items[ 1].Init("flags"    , 0, search_tokens,  0, 1);
+    search_tokens[0] = "Degree"  ; search_tokens[1] = "Histogram";
+    items[ 2].Init("#nodes"   , 2, search_tokens,  2, 1);
+    items[ 3].Init("#edges"   , 2, search_tokens,  4, 1);
+    search_tokens[0] = "CPU"     ; search_tokens[1] = "SSSP"; search_tokens[2] = " ";
+    items[ 4].Init("CPU depth", 3, search_tokens,  9, 1);
+    items[ 5].Init("CPU time" , 2, search_tokens,  4, 1);
+    search_tokens[0] = "GPU"     ; search_tokens[1] = "SSSP";
+    items[ 6].Init("GPU depth", 2, search_tokens, 10, 1);
+    items[ 7].Init("GPU time" , 2, search_tokens,  4, 1);
+    items[ 8].Init("GPU rate" , 2, search_tokens,  7, 1);
+    search_tokens[0] = "Label"   ; search_tokens[1] = "Validity";
+    items[ 9].Init("Label v"  , 2, search_tokens,  2, 1);
+    search_tokens[0] = "oversize";
+    items[10].Init("Oversize" , 1, search_tokens,  0, 0);
+    search_tokens[0] = "nodes_visited";
+    items[11].Init("#n visited",1, search_tokens,  1, 1);
+    search_tokens[0] = "edges"   ; search_tokens[1] = "visited";
+    items[12].Init("#e visited",2, search_tokens,  2, 1);
+    search_tokens[0] = "total"   ; search_tokens[1] = "queued";
+    items[13].Init("#queued"  , 2, search_tokens,  2, 1);
+    search_tokens[0] = "redundant"; search_tokens[1] = "work";
+    items[14].Init("Redudency", 2, search_tokens,  2, 1);
+
+    search_tokens[0] = "GPU_0"   ;
+    items[15].Init("GPU_0 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_1"   ;
+    items[16].Init("GPU_1 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_2"   ;
+    items[17].Init("GPU_2 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_3"   ;
+    items[18].Init("GPU_3 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_4"   ;
+    items[19].Init("GPU_4 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_5"   ;
+    items[20].Init("GPU_5 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_6"   ;
+    items[21].Init("GPU_6 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = "GPU_7"   ;
+    items[22].Init("GPU_7 mem", 1, search_tokens,  1, 1);
+    search_tokens[0] = " ";
+    items[23].Init("total mem", 1, search_tokens,  1, 1); 
+
+    search_tokens[0] = "queue_sizing";
+    items[24].Init("q-sizing" , 1, search_tokens,  2, 2);
+    search_tokens[0] = "in_sizing"   ;
+    items[25].Init("in-sizing", 1, search_tokens,  2, 1);
+    search_tokens[0] = "partition"; search_tokens[1] = "end.";
+    items[26].Init("partition time", 2, search_tokens, 2, 1);
+
+    for (int i=0; i<num_items; i++)
+    {
+        int length = 0;
+        if (items[i].offset <= 0)
+        {
+            length = items[i].num_search_tokens - items[i].offset + items[i].num_record_tokens;
+        } else {
+            length = items[i].num_search_tokens + items[i].offset + items[i].num_record_tokens;
+        }
+        if (length > max_length) max_length = length;
+
+        num_tokens += items[i].num_record_tokens;
+        if (items[i].num_record_tokens==0) num_tokens++;
+    }
+    current_tokens = new string[max_length];
+    
+    if (argc < 2) 
+    {
+        cout<<"Please give the directory name"<<endl; 
+        return -1;
+    }
+    
+    directory = opendir(argv[1]);
+    if (directory == NULL)
+    {
+        cout<<"Directory "<<argv[1]<<" can't be opened"<<endl;
+        return -1;
+    }
+
+    string dir_name = string(argv[1]);
+    fout.open(string(dir_name+".txt").c_str());
+    cout<<dir_name<<"\t";
+    for (int i=0; i<num_items;i++)
+    {
+        fout<<items[i].name<<"\t";
+        for (int j=1; j<items[i].num_record_tokens;j++)
+            fout<<"\t";
+    }
+    fout<<endl;
+
+    int num_data = 0;
+    while ((dir_item = readdir(directory)))
+    {
+        string file_name = string(dir_item->d_name);
+        string path_name = dir_name + "/" + file_name; 
+        if (stat( path_name.c_str(), &filestat)) continue;
+        if (S_ISDIR(filestat.st_mode)) continue;
+
+        if (file_name[0] =='.') continue;
+        ifstream fin;
+        fin.open(path_name.c_str());
+        if (!fin.is_open()) 
+        {
+            cout<<path_name<<" can't be opened"<<endl;
+            continue;
+        }
+
+        for (int i=0; i<num_items; i++)
+            items[i].Reset();
+        int pos = GetSubstringPos(file_name, dir_name);
+        string data_name = "", flag = "";
+        if (pos >=0)
+        {
+            for (int i=0; i<pos-1; i++)
+                data_name = data_name + file_name[i];
+            for (unsigned int i=pos + dir_name.length()+1; i<file_name.length() - 4; i++)
+                flag = flag + file_name[i];
+        }
+        //cout<<"new data: "<<data_name<<" "<<flag<<endl;
+        items[0].record_tokens[0] = data_name;
+        items[1].record_tokens[0] = flag;
+        for (int i=0; i<max_length; i++)
+            current_tokens[i] = "";
+        int last_count = 0;
+        while (!fin.eof() || last_count < max_length)
+        {
+            if (fin.eof()) last_count++;
+            string next_token = fin.eof() ? "" : GetNextToken(&fin, num_seperators, seperators);
+            for (int i=0; i<max_length-1; i++)
+                current_tokens[i] = current_tokens[i+1];
+            current_tokens[max_length-1] = next_token;
+            //cout<<next_token<<endl;
+            
+            for (int i=0; i<num_items; i++)
+            {
+                bool hit = TokensMatch(current_tokens, items[i].offset < 0? (-items[i].offset) : 0, items[i].search_tokens, items[i].num_search_tokens);
+                int num_r_tokens = items[i].num_record_tokens;
+                if (!hit) continue;
+                for (int j=0; j < num_r_tokens; j++)
+                {
+                    items[i].record_tokens[j] = items[i].offset < 0? current_tokens[j] : current_tokens[items[i].offset + j];
+                    //cout<<items[i].record_tokens[j]<<endl;
+                }
+                if (num_r_tokens == 0) 
+                {
+                    items[i].record_tokens[0] = "true_";
+                    //cout<<data_name<<" "<<flag<<" oversized"<<endl;
+                }
+                //cout<<items[i].name<<" hit : ";
+                //for (int j=0; j< (num_r_tokens == 0? 1: num_r_tokens); j++)
+                //    cout<<items[i].record_tokens[j]<<" ";
+                //cout<<endl;
+                //for (int j=0; j<max_length; j++)
+                //   cout<<current_tokens[j]<<" ";
+                //cout<<endl;
+            }
+        }
+        fin.close();
+
+        long long total_mem = 0;
+        for (int i=1; i<=8; i++)
+            total_mem += atoll(items[i+14].record_tokens[0].c_str());
+        items[23].record_tokens[0] = std::to_string(total_mem);
+
+        token_lists[num_data] = new string[num_tokens];
+        int temp_counter = 0;
+        for (int i=0; i<num_items; i++)
+        for (int j=0; j< (items[i].num_record_tokens ==0? 1: items[i].num_record_tokens); j++)
+        {
+            //fout<<items[i].record_tokens[j]<<"\t";
+            token_lists[num_data][temp_counter] = items[i].record_tokens[j];
+            temp_counter++;
+        }
+        //fout<<endl;
+        num_data ++;
+    };
+    cout<<"num_data = "<<num_data<<endl;
+
+    for (int i=0; i<num_data-1; i++)
+    for (int j=i+1; j<num_data; j++)
+    if (token_lists[i][0] > token_lists[j][0] || (token_lists[i][0] == token_lists[j][0] && token_lists[i][1] > token_lists[j][1])) {
+        for (int k=0; k<num_tokens; k++)
+        {
+            string temp_str = token_lists[i][k];
+            token_lists[i][k]=token_lists[j][k];
+            token_lists[j][k] = temp_str;
+        }
+    }
+
+    for (int i=0; i<num_data; i++)
+    {
+        for (int j=0; j<num_tokens-1; j++)
+            fout<<token_lists[i][j]<<"\t";
+        fout<<token_lists[i][num_tokens-1]<<endl;
+    }
+
+    fout.close();
+    closedir(directory);
+    return 0;
+}
+

--- a/tests/vn/make_summary.sh
+++ b/tests/vn/make_summary.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+g++ -Wall make_summary.cpp -o eval/make_summary -std=c++11
+cd eval
+
+DIRS="$(ls -d *K[48]0*)"
+
+for i in $DIRS
+do
+    if [ -d $i ] ;
+    then
+        #echo $i
+        ./make_summary $i
+    fi
+done
+
+cd ..
+

--- a/tests/vn/run.sh
+++ b/tests/vn/run.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+#get all execution files in ./bin
+files=(./bin/*)
+#split file names into arr
+arr=$(echo $files | tr " " "\n")
+max_ver_num="$"
+
+exe_file=${arr[0]}
+#iterate over all file names to get the largest version number
+for x in $arr
+do
+    output=$(grep -o "[0-9]\.[0-9]" <<<"$x")
+    if [ "$output" \> "$max_ver_num" ]; then
+        exe_file=$x
+    fi
+done
+
+OPTION[0]="--src=largestdegree --device=2,3 --partition-method=biasrandom --grid-size=768"
+#OPTION[0]="" #directed and do not mark-pred"
+OPTION[1]=${OPTION[0]}" --undirected" #undirected and do not mark-pred"
+OPTION[2]=${OPTION[0]}" --mark-path"  #directed and mark-pred"
+OPTION[3]=${OPTION[1]}" --mark-path" #undirected and mark-pred"
+#OPTION[4]=${OPTION[0]}" --idempotence"
+#OPTION[5]=${OPTION[1]}" --idempotence"
+#OPTION[6]=${OPTION[2]}" --idempotence"
+#OPTION[7]=${OPTION[3]}" --idempotence"
+
+MARK[0]=""
+MARK[1]=${MARK[0]}"_undir"
+MARK[2]=${MARK[0]}"_markpath"
+MARK[3]=${MARK[1]}"_markpath"
+#MARK[4]=${MARK[0]}".idempotence"
+#MARK[5]=${MARK[1]}".idempotence"
+#MARK[6]=${MARK[2]}".idempotence"
+#MARK[7]=${MARK[3]}".idempotence"
+
+#put OS and Device type here
+EXCUTION=$exe_file
+DATADIR="/data/gunrock_dataset/large"
+
+NAME[ 0]="ak2010"            && Q_SIZE_DIR[ 0]="0.05" && I_SIZE_DIR[ 0]="0.02" && Q_SIZE_UDIR[ 0]="3.00" && I_SIZE_UDIR[ 0]="1.00"
+
+NAME[ 1]="delaunay_n10"      && Q_SIZE_DIR[ 1]="2.00" && I_SIZE_DIR[ 1]="0.40" && Q_SIZE_UDIR[ 1]="2.50" && I_SIZE_UDIR[ 1]="0.60"
+NAME[ 2]="delaunay_n11"      && Q_SIZE_DIR[ 2]="2.00" && I_SIZE_DIR[ 2]="0.40" && Q_SIZE_UDIR[ 2]="2.50" && I_SIZE_UDIR[ 2]="0.50"
+NAME[ 3]="delaunay_n12"      && Q_SIZE_DIR[ 3]="2.00" && I_SIZE_DIR[ 3]="0.40" && Q_SIZE_UDIR[ 3]="2.00" && I_SIZE_UDIR[ 3]="0.50"
+NAME[ 4]="delaunay_n13"      && Q_SIZE_DIR[ 4]="0.25" && I_SIZE_DIR[ 4]="0.15" && Q_SIZE_UDIR[ 4]="1.40" && I_SIZE_UDIR[ 4]="0.30"
+NAME[ 5]="delaunay_n14"      && Q_SIZE_DIR[ 5]="0.25" && I_SIZE_DIR[ 5]="0.15" && Q_SIZE_UDIR[ 5]="1.20" && I_SIZE_UDIR[ 5]="0.30"
+NAME[ 6]="delaunay_n15"      && Q_SIZE_DIR[ 6]="0.25" && I_SIZE_DIR[ 6]="0.15" && Q_SIZE_UDIR[ 6]="1.20" && I_SIZE_UDIR[ 6]="0.30"
+NAME[ 7]="delaunay_n16"      && Q_SIZE_DIR[ 7]="0.25" && I_SIZE_DIR[ 7]="0.15" && Q_SIZE_UDIR[ 7]="0.90" && I_SIZE_UDIR[ 7]="0.20"
+NAME[ 8]="delaunay_n17"      && Q_SIZE_DIR[ 8]="0.25" && I_SIZE_DIR[ 8]="0.15" && Q_SIZE_UDIR[ 8]="0.80" && I_SIZE_UDIR[ 8]="0.20"
+NAME[ 9]="delaunay_n18"      && Q_SIZE_DIR[ 9]="0.25" && I_SIZE_DIR[ 9]="0.15" && Q_SIZE_UDIR[ 9]="0.80" && I_SIZE_UDIR[ 9]="0.20"
+NAME[10]="delaunay_n19"      && Q_SIZE_DIR[10]="0.25" && I_SIZE_DIR[10]="0.15" && Q_SIZE_UDIR[10]="0.80" && I_SIZE_UDIR[10]="0.20"
+NAME[11]="delaunay_n20"      && Q_SIZE_DIR[11]="0.25" && I_SIZE_DIR[11]="0.15" && Q_SIZE_UDIR[11]="0.80" && I_SIZE_UDIR[11]="0.20"
+NAME[12]="delaunay_n21"      && Q_SIZE_DIR[12]="0.25" && I_SIZE_DIR[12]="0.15" && Q_SIZE_UDIR[12]="0.80" && I_SIZE_UDIR[12]="0.20"
+NAME[13]="delaunay_n22"      && Q_SIZE_DIR[13]="0.25" && I_SIZE_DIR[13]="0.15" && Q_SIZE_UDIR[13]="0.80" && I_SIZE_UDIR[13]="0.20"
+NAME[14]="delaunay_n23"      && Q_SIZE_DIR[14]="0.25" && I_SIZE_DIR[14]="0.15" && Q_SIZE_UDIR[14]="0.80" && I_SIZE_UDIR[14]="0.20"
+NAME[15]="delaunay_n24"      && Q_SIZE_DIR[15]="0.25" && I_SIZE_DIR[15]="0.15" && Q_SIZE_UDIR[15]="0.80" && I_SIZE_UDIR[15]="0.20"
+
+NAME[16]="kron_g500-logn16"  && Q_SIZE_DIR[16]="180 " && I_SIZE_DIR[16]="1.50" && Q_SIZE_UDIR[16]="380 " && I_SIZE_UDIR[16]="1.75" 
+NAME[17]="kron_g500-logn17"  && Q_SIZE_DIR[17]="180 " && I_SIZE_DIR[17]="1.50" && Q_SIZE_UDIR[17]="380 " && I_SIZE_UDIR[17]="1.75" 
+NAME[18]="kron_g500-logn18"  && Q_SIZE_DIR[18]="180 " && I_SIZE_DIR[18]="1.50" && Q_SIZE_UDIR[18]="380 " && I_SIZE_UDIR[18]="1.75" 
+NAME[19]="kron_g500-logn19"  && Q_SIZE_DIR[19]="180 " && I_SIZE_DIR[19]="1.50" && Q_SIZE_UDIR[19]="380 " && I_SIZE_UDIR[19]="1.75" 
+NAME[20]="kron_g500-logn20"  && Q_SIZE_DIR[20]="180 " && I_SIZE_DIR[20]="1.50" && Q_SIZE_UDIR[20]="380 " && I_SIZE_UDIR[20]="1.75" 
+NAME[21]="kron_g500-logn21"  && Q_SIZE_DIR[21]="180 " && I_SIZE_DIR[21]="1.50" && Q_SIZE_UDIR[21]="380 " && I_SIZE_UDIR[21]="1.75" 
+
+NAME[22]="coAuthorsDBLP"     && Q_SIZE_DIR[22]="1.40" && I_SIZE_DIR[22]="0.50" && Q_SIZE_UDIR[22]="10.0" && I_SIZE_UDIR[22]="1.20" 
+NAME[23]="coAuthorsCiteseer" && Q_SIZE_DIR[23]="1.40" && I_SIZE_DIR[23]="0.50" && Q_SIZE_UDIR[23]="13.0" && I_SIZE_UDIR[23]="1.20" 
+NAME[24]="coPapersDBLP"      && Q_SIZE_DIR[24]="42.0" && I_SIZE_DIR[24]="1.50" && Q_SIZE_UDIR[24]="210 " && I_SIZE_UDIR[24]="2.40" 
+NAME[25]="coPapersCiteseer"  && Q_SIZE_DIR[25]="42.0" && I_SIZE_DIR[25]="1.50" && Q_SIZE_UDIR[25]="210 " && I_SIZE_UDIR[25]="2.40" 
+NAME[26]="citationCiteseer"  && Q_SIZE_DIR[26]="1.40" && I_SIZE_DIR[26]="0.50" && Q_SIZE_UDIR[26]="16.0" && I_SIZE_UDIR[26]="1.40" 
+NAME[27]="preferentialAttachment" && Q_SIZE_DIR[27]="6.0" && I_SIZE_DIR[27]="1.20" && Q_SIZE_UDIR[27]="20.0" && I_SIZE_UDIR[27]="1.50" 
+NAME[28]="soc-LiveJournal1"  && Q_SIZE_DIR[28]="30.0" && I_SIZE_DIR[28]="2.00" && Q_SIZE_UDIR[28]="50.0" && I_SIZE_UDIR[28]="2.00" 
+
+NAME[29]="roadNet-CA"        && Q_SIZE_DIR[29]="0.01" && I_SIZE_DIR[29]="0.01" && Q_SIZE_UDIR[29]="0.25" && I_SIZE_UDIR[29]="0.01" 
+NAME[30]="belgium_osm"       && Q_SIZE_DIR[30]="0.04" && I_SIZE_DIR[30]="0.04" && Q_SIZE_UDIR[30]="0.05" && I_SIZE_UDIR[30]="0.04" 
+NAME[31]="netherlands_osm"   && Q_SIZE_DIR[31]="0.01" && I_SIZE_DIR[31]="0.01" && Q_SIZE_UDIR[31]="0.02" && I_SIZE_UDIR[31]="0.01" 
+NAME[32]="italy_osm"         && Q_SIZE_DIR[32]="0.01" && I_SIZE_DIR[32]="0.01" && Q_SIZE_UDIR[32]="0.02" && I_SIZE_UDIR[32]="0.01" 
+NAME[33]="luxembourg_osm"    && Q_SIZE_DIR[33]="0.04" && I_SIZE_DIR[33]="0.04" && Q_SIZE_UDIR[33]="0.04" && I_SIZE_UDIR[33]="0.04" 
+NAME[34]="great-britain_osm" && Q_SIZE_DIR[34]="0.01" && I_SIZE_DIR[34]="0.01" && Q_SIZE_UDIR[34]="0.02" && I_SIZE_UDIR[34]="0.01" 
+NAME[35]="germany_osm"       && Q_SIZE_DIR[35]="0.01" && I_SIZE_DIR[35]="0.01" && Q_SIZE_UDIR[35]="0.02" && I_SIZE_UDIR[35]="0.01" 
+NAME[36]="asia_osm"          && Q_SIZE_DIR[36]="0.02" && I_SIZE_DIR[36]="0.02" && Q_SIZE_UDIR[36]="0.03" && I_SIZE_UDIR[36]="0.02" 
+NAME[37]="europe_osm"        && Q_SIZE_DIR[37]="0.02" && I_SIZE_DIR[37]="0.02" && Q_SIZE_UDIR[37]="0.02" && I_SIZE_UDIR[37]="0.02" 
+NAME[38]="road_usa"          && Q_SIZE_DIR[38]="0.01" && I_SIZE_DIR[38]="0.01" && Q_SIZE_UDIR[38]="0.15" && I_SIZE_UDIR[38]="0.01" 
+NAME[39]="road_central"      && Q_SIZE_DIR[39]="0.01" && I_SIZE_DIR[39]="0.01" && Q_SIZE_UDIR[39]="0.15" && I_SIZE_UDIR[39]="0.01" 
+
+NAME[40]="webbase-1M"        && Q_SIZE_DIR[40]="0.30" && I_SIZE_DIR[40]="0.15" && Q_SIZE_UDIR[40]="18.0" && I_SIZE_UDIR[40]="1.30" 
+NAME[41]="tweets"            && Q_SIZE_DIR[41]="10.0" && I_SIZE_DIR[41]="2.00" && Q_SIZE_UDIR[41]="5.50" && I_SIZE_UDIR[41]="2.00" 
+NAME[42]="bitcoin"           && Q_SIZE_DIR[42]="5.00" && I_SIZE_DIR[42]="2.00" && Q_SIZE_UDIR[42]="10.0" && I_SIZE_UDIR[42]="2.00" 
+NAME[43]="caidaRouterLevel"  && Q_SIZE_DIR[43]="1.50" && I_SIZE_DIR[43]="0.50" && Q_SIZE_UDIR[43]="12.0" && I_SIZE_UDIR[43]="1.20" 
+
+F[0]="0.0" && F[1]="0.1" && F[2]="0.2" && F[3]="0.3" && F[4]="0.4" && F[5]="0.5" && F[6]="0.6" && F[7]="0.7" && F[8]="0.8" && F[9]="0.9"
+F[10]="1.0"
+ 
+for k in {0..10}
+do
+    #put OS and Device type here
+    SUFFIX="ubuntu12.04_k40cx2_brp${F[$k]}"
+    mkdir -p eval/$SUFFIX
+
+    for i in  {0..43} 
+    do
+        for j in {0..3}
+        do
+            if [ "$j" -eq "0" ] || [ "$j" -eq "2" ] ; then
+                #echo $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=${Q_SIZE_DIR[$i]} --in-sizing=${I_SIZE_DIR[$i]} "> eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt"
+                #$EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=${Q_SIZE_DIR[$i]} --in-sizing=${I_SIZE_DIR[$i]} > eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt
+                echo $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=0.01 --in-sizing=0.01 --partition-factor=${F[$k]} "> eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt"
+                $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=0.01 --in-sizing=0.01 --partition-factor=${F[$k]} > eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt
+            else
+                #echo $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=${Q_SIZE_UDIR[$i]} --in-sizing=${I_SIZE_UDIR[$i]} "> eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt"
+                #$EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=${Q_SIZE_UDIR[$i]} --in-sizing=${I_SIZE_UDIR[$i]} > eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt
+                echo $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=0.01 --in-sizing=0.01 --partition-factor=${F[$k]} "> eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt"
+                $EXCUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx ${OPTION[$j]} --queue-sizing=0.01 --in-sizing=0.01 --partition-factor=${F[$k]} > eval/$SUFFIX/${NAME[$i]}_$SUFFIX${MARK[$j]}.txt
+            fi
+            sleep 1
+        done
+    done
+done
+

--- a/tests/vn/run_real.sh
+++ b/tests/vn/run_real.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+BASEOPTION="--src=randomize2 --queue-sizing=1.2 --iteration-num=16"
+BASEFLAG=""
+EXECUTION="./bin/test_sssp_8.0_x86_64"
+DATADIR="/data/gunrock_dataset/large"
+
+OPTION[0]="" && FLAG[0]=".default"
+OPTION[1]=" --undirected" && FLAG[1]=".undir"
+
+OPTION[4]="" && FLAG[4]=".skip_pred"
+OPTION[5]=" --mark-pred" && FLAG[5]=".mark_pred"
+
+OPTION[8]="" && FLAG[8]=".32bit_VertexId"
+OPTION[9]=" --64bit-SizeT" && FLAG[9]=".64bit_SizeT"
+# OPTION[10]=" --64bit-VertexId" && FLAG[10]=".64bit_VertexId"
+
+OPTION[11]="" && FLAG[11]=".DEF"
+OPTION[12]=" --traversal-mode=LB" && FLAG[12]=".LB"
+OPTION[13]=" --traversal-mode=TWC" && FLAG[13]=".TWC"
+OPTION[14]=" --traversal-mode=LB_CULL" && FLAG[14]=".LB_CULL"
+OPTION[15]=" --traversal-mode=LB_LIGHT_CULL" && FLAG[15]=".LB_LIGHT_CULL"
+OPTION[16]=" --traversal-mode=LB_LIGHT" && FLAG[16]=".LB_LIGHT"
+
+NAME[ 0]="soc-twitter-2010"  
+NAME[ 1]="hollywood-2009"    
+NAME[ 2]="soc-sinaweibo"     
+NAME[ 3]="soc-orkut"
+NAME[ 4]="soc-LiveJournal1"
+NAME[ 5]="uk-2002"
+NAME[ 6]="uk-2005"
+NAME[ 7]="webbase-2001"
+NAME[ 8]="indochina-2004"
+NAME[ 9]="arabic-2005"
+NAME[10]="europe_osm"
+NAME[11]="asia_osm"
+NAME[12]="germany_osm"
+NAME[13]="road_usa"
+NAME[14]="road_central"
+
+cd ~/Projects/gunrock_dev/gunrock/tests/sssp
+
+for d in 2 #{1..6}
+do
+    SUFFIX="CentOS6_6.k40cx${d}.rand"
+    mkdir -p eval/$SUFFIX
+    DEVICE="0"
+    for i in {1..8}
+    do
+        if [ "$i" -lt "$d" ]; then
+            DEVICE=$DEVICE",$i"
+        fi
+    done
+    #QUEUE_SIZING=1 #$(echo "${d}+1" | bc)
+
+    for o1 in {0..1}; do for o3 in {4..5}; do for o5 in {8..9}; do for o6 in {11..16}; do
+
+    OPTIONS=${BASEOPTION}${OPTION[${o1}]}${OPTION[${o3}]}${OPTION[${o5}]}${OPTION[${o6}]}
+    FLAGS=${BASEFLAG}${FLAG[${o1}]}${FLAG[${o3}]}${FLAG[${o5}]}${FLAG[${o6}]}
+
+    for i in 9 #{0..14}
+    do
+        echo $EXECUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx $OPTIONS --device=$DEVICE --jsondir=./eval/$SUFFIX "> ./eval/$SUFFIX/${NAME[$i]}${FLAGS}.txt"
+             $EXECUTION market $DATADIR/${NAME[$i]}/${NAME[$i]}.mtx $OPTIONS --device=$DEVICE --jsondir=./eval/$SUFFIX  > ./eval/$SUFFIX/${NAME[$i]}${FLAGS}.txt
+        sleep 1
+    done;
+    done; done; done; done
+done
+

--- a/tests/vn/run_rmat.sh
+++ b/tests/vn/run_rmat.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+OPTION="--undirected --src=largestdegree --traversal-mode=LB_CULL --iteration-num=10"
+MARK=".skip_pred.undir.LB_CULL.32bitSizeT"
+EXECUTION="./bin/test_sssp_7.5_x86_64"
+DATADIR="/data/gunrock_dataset/large"
+
+cd ~/Projects/gunrock_dev/gunrock/tests/sssp
+
+for d in 1 #{1..6}
+do
+    SUFFIX="CentOS6_6.k40cx${d}.rand"
+    mkdir -p eval/$SUFFIX
+    DEVICE="0"
+    for i in {1..8}
+    do
+        if [ "$i" -lt "$d" ]; then
+            DEVICE=$DEVICE",$i"
+        fi
+    done
+
+    QUEUE_SIZING=$(echo "${d} * 1.21" | bc)
+    for i in {20..25}
+    do
+        max_j=$(echo "29-${i}" | bc)
+        for j in {4..9}
+        do
+            max_j=max_j
+            #edge_factor=$(echo "2^${j}" | bc)
+            #if [ "$j" -le $((29-${i})) ]; then 
+            #    echo $EXECUTION grmat --rmat_scale=${i} --rmat_edgefactor=${edge_factor} $OPTION --queue-sizing=$QUEUE_SIZING --device=$DEVICE --jsondir=./eval/$SUFFIX "> ./eval/$SUFFIX/rmat_n${i}_${edge_factor}${MARK}.txt"
+            #         $EXECUTION grmat --rmat_scale=${i} --rmat_edgefactor=${edge_factor} $OPTION --queue-sizing=$QUEUE_SIZING --device=$DEVICE --jsondir=./eval/$SUFFIX > ./eval/$SUFFIX/rmat_n${i}_${edge_factor}${MARK}.txt
+            #    sleep 1
+            #fi
+        done
+    done
+
+    if [ "$d" -eq "1" ]; then
+        for i in {20..25}
+        do
+            edge_factor=$(echo "2^( 29 - ${i} )" | bc)
+            echo $EXECUTION rmat --rmat_scale=${i} --rmat_edgefactor=${edge_factor} $OPTION --queue-sizing=$QUEUE_SIZING --device=$DEVICE --jsondir=./eval/$SUFFIX "> ./eval/$SUFFIX/rmat_n${i}_${edge_factor}${MARK}.txt"
+                 $EXECUTION rmat --rmat_scale=${i} --rmat_edgefactor=${edge_factor} $OPTION --queue-sizing=$QUEUE_SIZING --device=$DEVICE --jsondir=./eval/$SUFFIX > ./eval/$SUFFIX/rmat_n${i}_${edge_factor}${MARK}.txt
+        done
+    fi
+done
+
+

--- a/tests/vn/test_vn.cu
+++ b/tests/vn/test_vn.cu
@@ -1,0 +1,141 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * test_sssp.cu
+ *
+ * @brief Simple test driver program for single source shortest path.
+ */
+
+#include <gunrock/app/sssp/sssp_app.cu>
+#include <gunrock/app/test_base.cuh>
+
+using namespace gunrock;
+
+/******************************************************************************
+* Main
+******************************************************************************/
+
+/**
+ * @brief Enclosure to the main function
+ */
+struct main_struct
+{
+    /**
+     * @brief the actual main function, after type switching
+     * @tparam VertexT    Type of vertex identifier
+     * @tparam SizeT      Type of graph size, i.e. type of edge identifier
+     * @tparam ValueT     Type of edge values
+     * @param  parameters Command line parameters
+     * @param  v,s,val    Place holders for type deduction
+     * \return cudaError_t error message(s), if any
+     */
+    template <
+        typename VertexT, // Use int as the vertex identifier
+        typename SizeT,   // Use int as the graph size type
+        typename ValueT>  // Use int as the value type
+    cudaError_t operator()(util::Parameters &parameters,
+        VertexT v, SizeT s, ValueT val)
+    {
+        typedef typename app::TestGraph<VertexT, SizeT, ValueT,
+            graph::HAS_EDGE_VALUES | graph::HAS_CSR>
+            GraphT;
+        typedef typename GraphT::CsrT CsrT;
+
+        cudaError_t retval = cudaSuccess;
+        util::CpuTimer cpu_timer;
+        GraphT graph; // graph we process on
+
+        cpu_timer.Start();
+        GUARD_CU(graphio::LoadGraph(parameters, graph));
+        // force edge values to be 1, don't enable this unless you really want to
+        //for (SizeT e=0; e < graph.edges; e++)
+        //    graph.CsrT::edge_values[e] = 1;
+        cpu_timer.Stop();
+        parameters.Set("load-time", cpu_timer.ElapsedMillis());
+        //GUARD_CU(graph.CsrT::edge_values.Print("", 100)); 
+        //util::PrintMsg("sizeof(VertexT) = " + std::to_string(sizeof(VertexT))
+        //    + ", sizeof(SizeT) = " + std::to_string(sizeof(SizeT))
+        //    + ", sizeof(ValueT) = " + std::to_string(sizeof(ValueT)));
+
+        GUARD_CU(app::Set_Srcs    (parameters, graph));
+        ValueT  **ref_distances = NULL;
+        int num_srcs = 0;
+        bool quick = parameters.Get<bool>("quick");
+        // compute reference CPU SSSP solution for source-distance
+        if (!quick)
+        {
+            bool quiet = parameters.Get<bool>("quiet");
+            std::string validation = parameters.Get<std::string>("validation");
+            util::PrintMsg("Computing reference value ...", !quiet);
+            std::vector<VertexT> srcs
+                = parameters.Get<std::vector<VertexT> >("srcs");
+            num_srcs = srcs.size();
+            SizeT nodes = graph.nodes;
+            ref_distances = new ValueT*[num_srcs];
+            for (int i = 0; i < num_srcs; i++)
+            {
+                ref_distances[i] = (ValueT*)malloc(sizeof(ValueT) * nodes);
+                VertexT src = srcs[i];
+                util::PrintMsg("__________________________", !quiet);
+                float elapsed = app::sssp::CPU_Reference(
+                    graph.csr(), ref_distances[i], NULL,
+                    src, quiet, false);
+                util::PrintMsg("--------------------------\nRun "
+                    + std::to_string(i) + " elapsed: "
+                    + std::to_string(elapsed) + " ms, src = "
+                    + std::to_string(src), !quiet);
+            }
+        }
+
+        std::vector<std::string> switches{"mark-pred", "advance-mode"};
+        GUARD_CU(app::Switch_Parameters(parameters, graph, switches,
+            [ref_distances](util::Parameters &parameters, GraphT &graph)
+            {
+                return app::sssp::RunTests(parameters, graph, ref_distances);
+            }));
+
+        if (!quick)
+        {
+            for (int i = 0; i < num_srcs; i ++)
+            {
+                free(ref_distances[i]); ref_distances[i] = NULL;
+            }
+            delete[] ref_distances; ref_distances = NULL;
+        }
+        return retval;
+    }
+};
+
+int main(int argc, char** argv)
+{
+    cudaError_t retval = cudaSuccess;
+    util::Parameters parameters("test sssp");
+    GUARD_CU(graphio::UseParameters(parameters));
+    GUARD_CU(app::sssp::UseParameters(parameters));
+    GUARD_CU(app::UseParameters_test(parameters));
+    GUARD_CU(parameters.Parse_CommandLine(argc, argv));
+    if (parameters.Get<bool>("help"))
+    {
+        parameters.Print_Help();
+        return cudaSuccess;
+    }
+    GUARD_CU(parameters.Check_Required());
+
+    return app::Switch_Types<
+        app::VERTEXT_U32B | app::VERTEXT_U64B |
+        app::SIZET_U32B | app::SIZET_U64B |
+        app::VALUET_U32B | app::DIRECTED | app::UNDIRECTED>
+        (parameters, main_struct());
+}
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:


### PR DESCRIPTION
#### Vertex nomination (VN) kernel

For each node in the graph, compute the minimum distance to a node in the source set.  This is equivalent to SSSP, but w/ multiple nodes in the initial frontier.

Running this app w/ `--src a,b,c` uses nodes `a`, `b` and `c` as the source set.  This is slightly different from SSSP, which runs SSSP from `a`, then from `b`, then from `c`.  If we can figure out a way to pass _sets_ of nodes via `src`, I can make the appropriate changes -- this could possibly look like 
```
--src a+b+c,d+e+f
```
to pass sets `{a,b,c}` and `{d,e,f}`.

To see the difference between `vn` and `sssp`, you can look at this diff: 
    https://github.com/bkj/gunrock/commit/0e4e94969b012f7dd6191856490b4064cffb17d9

The differences are not particularly large, but since `sssp` is a canonical graph operation, I chose to implement this in a separate application.

##### Notes
 - single-GPU implementation only
 - need a C-interface w/o templates?

##### Questions
 - in general, what is the use case for `num_runs > 1` in `*_app.cu` ? 