### PR TITLE
[dev-refactor][HIVE] graph_projections

### DIFF
--- a/gunrock/app/proj/proj_app.cu
+++ b/gunrock/app/proj/proj_app.cu
@@ -1,0 +1,337 @@
+// ----------------------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------------------
+
+/**
+ * @file proj_app.cu
+ *
+ * @brief Simple Gunrock Application
+ */
+
+#include <gunrock/gunrock.h>
+#include <gunrock/util/test_utils.cuh>
+#include <gunrock/graphio/graphio.cuh>
+#include <gunrock/app/app_base.cuh>
+#include <gunrock/app/test_base.cuh>
+
+#include <gunrock/app/proj/proj_enactor.cuh>
+#include <gunrock/app/proj/proj_test.cuh>
+
+namespace gunrock {
+namespace app {
+namespace proj {
+
+
+cudaError_t UseParameters(util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(UseParameters_app(parameters));
+    GUARD_CU(UseParameters_problem(parameters));
+    GUARD_CU(UseParameters_enactor(parameters));
+
+    // <TODO> add app specific parameters, eg:
+    // GUARD_CU(parameters.Use<std::string>(
+    //    "src",
+    //    util::REQUIRED_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
+    //    "0",
+    //    "<Vertex-ID|random|largestdegree> The source vertices\n"
+    //    "\tIf random, randomly select non-zero degree vertices;\n"
+    //    "\tIf largestdegree, select vertices with largest degrees",
+    //    __FILE__, __LINE__));
+    // </TODO>
+
+    return retval;
+}
+
+/**
+ * @brief Run proj tests
+ * @tparam     GraphT        Type of the graph
+ * @tparam     ValueT        Type of the distances
+ * @param[in]  parameters    Excution parameters
+ * @param[in]  graph         Input graph
+...
+ * @param[in]  target        where to perform the app
+ * \return cudaError_t error message(s), if any
+ */
+template <typename GraphT>
+cudaError_t RunTests(
+    util::Parameters &parameters,
+    GraphT           &graph,
+    // <TODO> add problem specific reference results, e.g.:
+    typename GraphT::ValueT *ref_degrees,
+    // </TODO>
+    util::Location target)
+{
+
+    cudaError_t retval = cudaSuccess;
+
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::ValueT  ValueT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef Problem<GraphT>          ProblemT;
+    typedef Enactor<ProblemT>        EnactorT;
+
+    // CLI parameters
+    bool quiet_mode = parameters.Get<bool>("quiet");
+    int  num_runs   = parameters.Get<int >("num-runs");
+    std::string validation = parameters.Get<std::string>("validation");
+    util::Info info("proj", parameters, graph);
+
+    util::CpuTimer cpu_timer, total_timer;
+    cpu_timer.Start(); total_timer.Start();
+
+    // <TODO> get problem specific inputs, e.g.:
+    // std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+    // printf("RunTests: %d srcs: src[0]=%d\n", srcs.size(), srcs[0]);
+    // </TODO>
+
+    // <TODO> allocate problem specific host data, e.g.:
+    ValueT *h_degrees = new ValueT[graph.nodes];
+    // </TODO>
+
+    // Allocate problem and enactor on GPU, and initialize them
+    ProblemT problem(parameters);
+    EnactorT enactor;
+    GUARD_CU(problem.Init(graph, target));
+    GUARD_CU(enactor.Init(problem, target));
+
+    cpu_timer.Stop();
+    parameters.Set("preprocess-time", cpu_timer.ElapsedMillis());
+
+    for (int run_num = 0; run_num < num_runs; ++run_num) {
+        GUARD_CU(problem.Reset(
+            // <TODO> problem specific data if necessary, eg:
+            // src,
+            // </TODO>
+            target
+        ));
+        GUARD_CU(enactor.Reset(
+            // <TODO> problem specific data if necessary:
+            // srcs[run_num % srcs.size()],
+            // </TODO>
+            target
+        ));
+
+        util::PrintMsg("__________________________", !quiet_mode);
+
+        cpu_timer.Start();
+        GUARD_CU(enactor.Enact(
+            // <TODO> problem specific data if necessary:
+            // srcs[run_num % srcs.size()]
+            // </TODO>
+        ));
+        cpu_timer.Stop();
+        info.CollectSingleRun(cpu_timer.ElapsedMillis());
+
+        util::PrintMsg("--------------------------\nRun "
+            + std::to_string(run_num) + " elapsed: "
+            + std::to_string(cpu_timer.ElapsedMillis()) +
+            ", #iterations = "
+            + std::to_string(enactor.enactor_slices[0]
+                .enactor_stats.iteration), !quiet_mode);
+
+        if (validation == "each") {
+
+            GUARD_CU(problem.Extract(
+                // <TODO> problem specific data
+                h_degrees
+                // </TODO>
+            ));
+            SizeT num_errors = Validate_Results(
+                parameters,
+                graph,
+                // <TODO> problem specific data
+                h_degrees, ref_degrees,
+                // </TODO>
+                false);
+        }
+    }
+
+    cpu_timer.Start();
+
+    GUARD_CU(problem.Extract(
+        // <TODO> problem specific data
+        h_degrees
+        // </TODO>
+    ));
+    if (validation == "last") {
+        SizeT num_errors = Validate_Results(
+            parameters,
+            graph,
+            // <TODO> problem specific data
+            h_degrees, ref_degrees,
+            // </TODO>
+            false);
+    }
+
+    // compute running statistics
+    // TODO: change NULL to problem specific per-vertex visited marker, e.g. h_distances
+    info.ComputeTraversalStats(enactor, (VertexT*)NULL);
+    //Display_Memory_Usage(problem);
+    #ifdef ENABLE_PERFORMANCE_PROFILING
+        //Display_Performance_Profiling(enactor);
+    #endif
+
+    // Clean up
+    GUARD_CU(enactor.Release(target));
+    GUARD_CU(problem.Release(target));
+    // <TODO> Release problem specific data, e.g.:
+    delete[] h_degrees; h_degrees   = NULL;
+    // </TODO>
+    cpu_timer.Stop(); total_timer.Stop();
+
+    info.Finalize(cpu_timer.ElapsedMillis(), total_timer.ElapsedMillis());
+    return retval;
+}
+
+} // namespace proj
+} // namespace app
+} // namespace gunrock
+
+// ===========================================================================================
+// ========================= CODE BELOW THIS LINE NOT NEEDED FOR TESTS =======================
+// ===========================================================================================
+
+// /*
+// * @brief Entry of gunrock_template function
+// * @tparam     GraphT     Type of the graph
+// * @tparam     ValueT     Type of the distances
+// * @param[in]  parameters Excution parameters
+// * @param[in]  graph      Input graph
+// * @param[out] distances  Return shortest distance to source per vertex
+// * @param[out] preds      Return predecessors of each vertex
+// * \return     double     Return accumulated elapsed times for all runs
+// */
+// template <typename GraphT, typename ValueT = typename GraphT::ValueT>
+// double gunrock_Template(
+//     gunrock::util::Parameters &parameters,
+//     GraphT &graph
+//     // TODO: add problem specific outputs, e.g.:
+//     //ValueT **distances
+//     )
+// {
+//     typedef typename GraphT::VertexT VertexT;
+//     typedef gunrock::app::Template::Problem<GraphT  > ProblemT;
+//     typedef gunrock::app::Template::Enactor<ProblemT> EnactorT;
+//     gunrock::util::CpuTimer cpu_timer;
+//     gunrock::util::Location target = gunrock::util::DEVICE;
+//     double total_time = 0;
+//     if (parameters.UseDefault("quiet"))
+//         parameters.Set("quiet", true);
+
+//     // Allocate problem and enactor on GPU, and initialize them
+//     ProblemT problem(parameters);
+//     EnactorT enactor;
+//     problem.Init(graph  , target);
+//     enactor.Init(problem, target);
+
+//     int num_runs = parameters.Get<int>("num-runs");
+//     // TODO: get problem specific inputs, e.g.:
+//     // std::vector<VertexT> srcs = parameters.Get<std::vector<VertexT>>("srcs");
+//     // int num_srcs = srcs.size();
+//     for (int run_num = 0; run_num < num_runs; ++run_num)
+//     {
+//         // TODO: problem specific inputs, e.g.:
+//         // int src_num = run_num % num_srcs;
+//         // VertexT src = srcs[src_num];
+//         problem.Reset(/*src,*/ target);
+//         enactor.Reset(/*src,*/ target);
+
+//         cpu_timer.Start();
+//         enactor.Enact(/*src*/);
+//         cpu_timer.Stop();
+
+//         total_time += cpu_timer.ElapsedMillis();
+//         // TODO: extract problem specific data, e.g.:
+//         problem.Extract(/*distances[src_num]*/);
+//     }
+
+//     enactor.Release(target);
+//     problem.Release(target);
+//     // TODO: problem specific clean ups, e.g.:
+//     // srcs.clear();
+//     return total_time;
+// }
+
+
+//  * @brief Simple interface take in graph as CSR format
+//  * @param[in]  num_nodes   Number of veritces in the input graph
+//  * @param[in]  num_edges   Number of edges in the input graph
+//  * @param[in]  row_offsets CSR-formatted graph input row offsets
+//  * @param[in]  col_indices CSR-formatted graph input column indices
+//  * @param[in]  edge_values CSR-formatted graph input edge weights
+//  * @param[in]  num_runs    Number of runs to perform SSSP
+//  * @param[in]  sources     Sources to begin traverse, one for each run
+//  * @param[in]  mark_preds  Whether to output predecessor info
+//  * @param[out] distances   Return shortest distance to source per vertex
+//  * @param[out] preds       Return predecessors of each vertex
+//  * \return     double      Return accumulated elapsed times for all runs
+
+// template <
+//     typename VertexT = int,
+//     typename SizeT   = int,
+//     typename GValueT = unsigned int,
+//     typename TValueT = GValueT>
+// float Template(
+//     const SizeT        num_nodes,
+//     const SizeT        num_edges,
+//     const SizeT       *row_offsets,
+//     const VertexT     *col_indices,
+//     const GValueT     *edge_values,
+//     const int          num_runs
+//     // TODO: add problem specific inputs and outputs, e.g.:
+//     //      VertexT     *sources,
+//     //      SSSPValueT **distances
+//     )
+// {
+//     // TODO: change to other graph representation, if not using CSR
+//     typedef typename gunrock::app::TestGraph<VertexT, SizeT, GValueT,
+//         gunrock::graph::HAS_EDGE_VALUES | gunrock::graph::HAS_CSR>
+//         GraphT;
+//     typedef typename GraphT::CsrT CsrT;
+
+//     // Setup parameters
+//     gunrock::util::Parameters parameters("Template");
+//     gunrock::graphio::UseParameters(parameters);
+//     gunrock::app::Template::UseParameters(parameters);
+//     gunrock::app::UseParameters_test(parameters);
+//     parameters.Parse_CommandLine(0, NULL);
+//     parameters.Set("graph-type", "by-pass");
+//     parameters.Set("num-runs", num_runs);
+//     // TODO: problem specific inputs, e.g.:
+//     // std::vector<VertexT> srcs;
+//     // for (int i = 0; i < num_runs; i ++)
+//     //     srcs.push_back(sources[i]);
+//     // parameters.Set("srcs", srcs);
+
+//     bool quiet = parameters.Get<bool>("quiet");
+//     GraphT graph;
+//     // Assign pointers into gunrock graph format
+//     // TODO: change to other graph representation, if not using CSR
+//     graph.CsrT::Allocate(num_nodes, num_edges, gunrock::util::HOST);
+//     graph.CsrT::row_offsets   .SetPointer(row_offsets, num_nodes + 1, gunrock::util::HOST);
+//     graph.CsrT::column_indices.SetPointer(col_indices, num_edges, gunrock::util::HOST);
+//     graph.CsrT::edge_values   .SetPointer(edge_values, num_edges, gunrock::util::HOST);
+//     graph.FromCsr(graph.csr(), true, quiet);
+//     gunrock::graphio::LoadGraph(parameters, graph);
+
+//     // Run the Template
+//     // TODO: add problem specific outputs, e.g.
+//     double elapsed_time = gunrock_Template(parameters, graph /*, distances*/);
+
+//     // Cleanup
+//     graph.Release();
+//     // TODO: problem specific cleanup
+//     // srcs.clear();
+
+//     return elapsed_time;
+// }
+
+// // Leave this at the end of the file
+// // Local Variables:
+// // mode:c++
+// // c-file-style: "NVIDIA"
+// // End:

--- a/gunrock/app/proj/proj_enactor.cuh
+++ b/gunrock/app/proj/proj_enactor.cuh
@@ -1,0 +1,413 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * Template_enactor.cuh
+ *
+ * @brief proj Problem Enactor
+ */
+
+#pragma once
+
+#include <gunrock/app/enactor_base.cuh>
+#include <gunrock/app/enactor_iteration.cuh>
+#include <gunrock/app/enactor_loop.cuh>
+#include <gunrock/oprtr/oprtr.cuh>
+
+#include <gunrock/app/proj/proj_problem.cuh>
+
+
+namespace gunrock {
+namespace app {
+namespace proj {
+
+/**
+ * @brief Speciflying parameters for proj Enactor
+ * @param parameters The util::Parameter<...> structure holding all parameter info
+ * \return cudaError_t error message(s), if any
+ */
+cudaError_t UseParameters_enactor(util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+    GUARD_CU(app::UseParameters_enactor(parameters));
+
+    // <TODO> if needed, add command line parameters used by the enactor here
+    // </TODO>
+
+    return retval;
+}
+
+/**
+ * @brief defination of proj iteration loop
+ * @tparam EnactorT Type of enactor
+ */
+template <typename EnactorT>
+struct projIterationLoop : public IterationLoopBase
+    <EnactorT, Use_FullQ | Push
+    // <TODO>if needed, stack more option, e.g.:
+    // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
+    // Update_Predecessors : 0x0)
+    // </TODO>
+    >
+{
+    typedef typename EnactorT::VertexT VertexT;
+    typedef typename EnactorT::SizeT   SizeT;
+    typedef typename EnactorT::ValueT  ValueT;
+    typedef typename EnactorT::Problem::GraphT::CsrT CsrT;
+    typedef typename EnactorT::Problem::GraphT::GpT  GpT;
+
+    typedef IterationLoopBase
+        <EnactorT, Use_FullQ | Push
+        // <TODO> add the same options as in template parameters here, e.g.:
+        // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
+        // Update_Predecessors : 0x0)
+        // </TODO>
+        > BaseIterationLoop;
+
+    projIterationLoop() : BaseIterationLoop() {}
+
+    /**
+     * @brief Core computation of proj, one iteration
+     * @param[in] peer_ Which GPU peers to work on, 0 means local
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Core(int peer_ = 0)
+    {
+        // --
+        // Alias variables
+
+        auto &data_slice = this -> enactor ->
+            problem -> data_slices[this -> gpu_num][0];
+
+        auto &enactor_slice = this -> enactor ->
+            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
+
+        auto &enactor_stats    = enactor_slice.enactor_stats;
+        auto &graph            = data_slice.sub_graph[0];
+        auto &frontier         = enactor_slice.frontier;
+        auto &oprtr_parameters = enactor_slice.oprtr_parameters;
+        auto &retval           = enactor_stats.retval;
+        auto &iteration        = enactor_stats.iteration;
+
+        // <TODO> add problem specific data alias here:
+        auto &degrees = data_slice.degrees;
+        auto &visited = data_slice.visited;
+        // </TODO>
+
+        // --
+        // Define operations
+
+        // advance operation
+        auto advance_op = [
+            // <TODO> pass data to lambda
+            degrees,
+            visited
+            // </TODO>
+        ] __host__ __device__ (
+            const VertexT &src, VertexT &dest, const SizeT &edge_id,
+            const VertexT &input_item, const SizeT &input_pos,
+            SizeT &output_pos) -> bool
+        {
+            // <TODO> Implement advance operation
+
+            // Mark src and dest as visited
+            atomicMax(visited + src, 1);
+            auto dest_visited = atomicMax(visited + dest, 1);
+
+            // Increment degree of src
+            atomicAdd(degrees + src, 1);
+
+            // Add dest to queue if previously unsen
+            return dest_visited == 0;
+
+            // </TODO>
+        };
+
+        // filter operation
+        auto filter_op = [
+            // <TODO> pass data to lambda
+            // </TODO>
+        ] __host__ __device__ (
+            const VertexT &src, VertexT &dest, const SizeT &edge_id,
+            const VertexT &input_item, const SizeT &input_pos,
+            SizeT &output_pos) -> bool
+        {
+            // <TODO> implement filter operation
+            return true;
+            // </TODO>
+        };
+
+        // --
+        // Run
+
+        // <TODO> some of this may need to be edited depending on algorithmic needs
+        // !! How much variation between apps is there in these calls?
+
+        GUARD_CU(oprtr::Advance<oprtr::OprtrType_V2V>(
+            graph.csr(), frontier.V_Q(), frontier.Next_V_Q(),
+            oprtr_parameters, advance_op, filter_op));
+
+        if (oprtr_parameters.advance_mode != "LB_CULL" &&
+            oprtr_parameters.advance_mode != "LB_LIGHT_CULL")
+        {
+            frontier.queue_reset = false;
+            GUARD_CU(oprtr::Filter<oprtr::OprtrType_V2V>(
+                graph.csr(), frontier.V_Q(), frontier.Next_V_Q(),
+                oprtr_parameters, filter_op));
+        }
+
+        // Get back the resulted frontier length
+        GUARD_CU(frontier.work_progress.GetQueueLength(
+            frontier.queue_index, frontier.queue_length,
+            false, oprtr_parameters.stream, true));
+
+        // </TODO>
+
+        return retval;
+    }
+
+    /**
+     * @brief Routine to combine received data and local data
+     * @tparam NUM_VERTEX_ASSOCIATES Number of data associated with each transmition item, typed VertexT
+     * @tparam NUM_VALUE__ASSOCIATES Number of data associated with each transmition item, typed ValueT
+     * @param  received_length The numver of transmition items received
+     * @param[in] peer_ which peer GPU the data came from
+     * \return cudaError_t error message(s), if any
+     */
+    template <
+        int NUM_VERTEX_ASSOCIATES,
+        int NUM_VALUE__ASSOCIATES>
+    cudaError_t ExpandIncoming(SizeT &received_length, int peer_)
+    {
+
+        // ================ INCOMPLETE TEMPLATE - MULTIGPU ====================
+
+        auto &data_slice    = this -> enactor ->
+            problem -> data_slices[this -> gpu_num][0];
+        auto &enactor_slice = this -> enactor ->
+            enactor_slices[this -> gpu_num * this -> enactor -> num_gpus + peer_];
+        //auto iteration = enactor_slice.enactor_stats.iteration;
+        // TODO: add problem specific data alias here, e.g.:
+        // auto         &distances          =   data_slice.distances;
+
+        auto expand_op = [
+        // TODO: pass data used by the lambda, e.g.:
+        // distances
+        ] __host__ __device__(
+            VertexT &key, const SizeT &in_pos,
+            VertexT *vertex_associate_ins,
+            ValueT  *value__associate_ins) -> bool
+        {
+            // TODO: fill in the lambda to combine received and local data, e.g.:
+            // ValueT in_val  = value__associate_ins[in_pos];
+            // ValueT old_val = atomicMin(distances + key, in_val);
+            // if (old_val <= in_val)
+            //     return false;
+            return true;
+        };
+
+        cudaError_t retval = BaseIterationLoop:: template ExpandIncomingBase
+            <NUM_VERTEX_ASSOCIATES, NUM_VALUE__ASSOCIATES>
+            (received_length, peer_, expand_op);
+        return retval;
+    }
+}; // end of projIteration
+
+/**
+ * @brief Template enactor class.
+ * @tparam _Problem Problem type we process on
+ * @tparam ARRAY_FLAG Flags for util::Array1D used in the enactor
+ * @tparam cudaHostRegisterFlag Flags for util::Array1D used in the enactor
+ */
+template <
+    typename _Problem,
+    util::ArrayFlag ARRAY_FLAG = util::ARRAY_NONE,
+    unsigned int cudaHostRegisterFlag = cudaHostRegisterDefault>
+class Enactor :
+    public EnactorBase<
+        typename _Problem::GraphT,
+        typename _Problem::GraphT::VertexT, // TODO: change to other label types used for the operators, e.g.: typename _Problem::LabelT,
+        typename _Problem::GraphT::ValueT, // TODO: change to other value types used for inter GPU communication, e.g.: typename _Problem::ValueT,
+        ARRAY_FLAG, cudaHostRegisterFlag>
+{
+public:
+    typedef _Problem                   Problem ;
+    typedef typename Problem::SizeT    SizeT   ;
+    typedef typename Problem::VertexT  VertexT ;
+    typedef typename Problem::GraphT   GraphT  ;
+    typedef typename GraphT::VertexT   LabelT  ;
+    typedef typename GraphT::ValueT    ValueT  ;
+    typedef EnactorBase<GraphT, LabelT, ValueT, ARRAY_FLAG, cudaHostRegisterFlag>
+        BaseEnactor;
+    typedef Enactor<Problem, ARRAY_FLAG, cudaHostRegisterFlag>
+        EnactorT;
+    typedef projIterationLoop<EnactorT>
+        IterationT;
+
+    Problem *problem;
+    IterationT *iterations;
+
+    /**
+     * @brief proj constructor
+     */
+    Enactor() :
+        BaseEnactor("Template"),
+        problem    (NULL  )
+    {
+        // <TODO> change according to algorithmic needs
+        this -> max_num_vertex_associates = 0;
+        this -> max_num_value__associates = 1;
+        // </TODO>
+    }
+
+    /**
+     * @brief proj destructor
+     */
+    virtual ~Enactor() { /*Release();*/ }
+
+    /*
+     * @brief Releasing allocated memory space
+     * @param target The location to release memory from
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Release(util::Location target = util::LOCATION_ALL)
+    {
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseEnactor::Release(target));
+        delete []iterations; iterations = NULL;
+        problem = NULL;
+        return retval;
+    }
+
+    /**
+     * @brief Initialize the problem.
+     * @param[in] problem The problem object.
+     * @param[in] target Target location of data
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Init(
+        Problem          &problem,
+        util::Location    target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        this->problem = &problem;
+
+        // Lazy initialization
+        GUARD_CU(BaseEnactor::Init(
+            problem, Enactor_None,
+            // <TODO> change to how many frontier queues, and their types
+            2, NULL,
+            // </TODO>
+            target, false));
+        for (int gpu = 0; gpu < this -> num_gpus; gpu ++) {
+            GUARD_CU(util::SetDevice(this -> gpu_idx[gpu]));
+            auto &enactor_slice = this -> enactor_slices[gpu * this -> num_gpus + 0];
+            auto &graph = problem.sub_graphs[gpu];
+            GUARD_CU(enactor_slice.frontier.Allocate(
+                graph.nodes, graph.edges, this -> queue_factors));
+        }
+
+        iterations = new IterationT[this -> num_gpus];
+        for (int gpu = 0; gpu < this -> num_gpus; gpu ++) {
+            GUARD_CU(iterations[gpu].Init(this, gpu));
+        }
+
+        GUARD_CU(this -> Init_Threads(this,
+            (CUT_THREADROUTINE)&(GunrockThread<EnactorT>)));
+        return retval;
+    }
+
+    /**
+      * @brief one run of proj, to be called within GunrockThread
+      * @param thread_data Data for the CPU thread
+      * \return cudaError_t error message(s), if any
+      */
+    cudaError_t Run(ThreadSlice &thread_data)
+    {
+        gunrock::app::Iteration_Loop<
+            // <TODO> change to how many {VertexT, ValueT} data need to communicate
+            //       per element in the inter-GPU sub-frontiers
+            0, 1,
+            // </TODO>
+            IterationT>(
+            thread_data, iterations[thread_data.thread_num]);
+        return cudaSuccess;
+    }
+
+    /**
+     * @brief Reset enactor
+...
+     * @param[in] target Target location of data
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Reset(
+        // <TODO> problem specific data if necessary, eg
+        VertexT src = 0,
+        // </TODO>
+        util::Location target = util::DEVICE)
+    {
+        typedef typename GraphT::GpT GpT;
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseEnactor::Reset(target));
+
+        // <TODO> Initialize frontiers according to the algorithm:
+        // In this case, we add a single `src` to the frontier
+        for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+           if ((this->num_gpus == 1) ||
+                (gpu == this->problem->org_graph->GpT::partition_table[src])) {
+               this -> thread_slices[gpu].init_size = 1;
+               for (int peer_ = 0; peer_ < this -> num_gpus; peer_++) {
+                   auto &frontier = this -> enactor_slices[gpu * this -> num_gpus + peer_].frontier;
+                   frontier.queue_length = (peer_ == 0) ? 1 : 0;
+                   if (peer_ == 0) {
+                       GUARD_CU(frontier.V_Q() -> ForEach(
+                           [src]__host__ __device__ (VertexT &v) {
+                           v = src;
+                       }, 1, target, 0));
+                   }
+               }
+           } else {
+                this -> thread_slices[gpu].init_size = 0;
+                for (int peer_ = 0; peer_ < this -> num_gpus; peer_++) {
+                    this -> enactor_slices[gpu * this -> num_gpus + peer_].frontier.queue_length = 0;
+                }
+           }
+        }
+        // </TODO>
+
+        GUARD_CU(BaseEnactor::Sync());
+        return retval;
+    }
+
+    /**
+     * @brief Enacts a proj computing on the specified graph.
+...
+     * \return cudaError_t error message(s), if any
+     */
+    cudaError_t Enact(
+        // <TODO> problem specific data if necessary, eg
+        VertexT src = 0
+        // </TODO>
+    )
+    {
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(this -> Run_Threads(this));
+        util::PrintMsg("GPU Template Done.", this -> flag & Debug);
+        return retval;
+    }
+};
+
+} // namespace Template
+} // namespace app
+} // namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/gunrock/app/proj/proj_enactor.cuh
+++ b/gunrock/app/proj/proj_enactor.cuh
@@ -377,7 +377,7 @@ public:
     {
         cudaError_t retval = cudaSuccess;
         GUARD_CU(this -> Run_Threads(this));
-        util::PrintMsg("GPU Template Done.", this -> flag & Debug);
+        util::PrintMsg("GPU graph_projections Done.", this -> flag & Debug);
         return retval;
     }
 };

--- a/gunrock/app/proj/proj_enactor.cuh
+++ b/gunrock/app/proj/proj_enactor.cuh
@@ -35,10 +35,6 @@ cudaError_t UseParameters_enactor(util::Parameters &parameters)
 {
     cudaError_t retval = cudaSuccess;
     GUARD_CU(app::UseParameters_enactor(parameters));
-
-    // <TODO> if needed, add command line parameters used by the enactor here
-    // </TODO>
-
     return retval;
 }
 
@@ -48,12 +44,7 @@ cudaError_t UseParameters_enactor(util::Parameters &parameters)
  */
 template <typename EnactorT>
 struct projIterationLoop : public IterationLoopBase
-    <EnactorT, Use_FullQ | Push
-    // <TODO>if needed, stack more option, e.g.:
-    // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
-    // Update_Predecessors : 0x0)
-    // </TODO>
-    >
+    <EnactorT, Use_FullQ | Push>
 {
     typedef typename EnactorT::VertexT VertexT;
     typedef typename EnactorT::SizeT   SizeT;
@@ -62,12 +53,7 @@ struct projIterationLoop : public IterationLoopBase
     typedef typename EnactorT::Problem::GraphT::GpT  GpT;
 
     typedef IterationLoopBase
-        <EnactorT, Use_FullQ | Push
-        // <TODO> add the same options as in template parameters here, e.g.:
-        // | (((EnactorT::Problem::FLAG & Mark_Predecessors) != 0) ?
-        // Update_Predecessors : 0x0)
-        // </TODO>
-        > BaseIterationLoop;
+        <EnactorT, Use_FullQ | Push> BaseIterationLoop;
 
     projIterationLoop() : BaseIterationLoop() {}
 
@@ -94,52 +80,43 @@ struct projIterationLoop : public IterationLoopBase
         auto &retval           = enactor_stats.retval;
         auto &iteration        = enactor_stats.iteration;
 
-        // <TODO> add problem specific data alias here:
-        auto &degrees = data_slice.degrees;
-        auto &visited = data_slice.visited;
-        // </TODO>
+        auto &projections = data_slice.projections;
 
         // --
         // Define operations
 
         // advance operation
         auto advance_op = [
-            // <TODO> pass data to lambda
-            degrees,
-            visited
-            // </TODO>
+            graph,
+            projections
         ] __host__ __device__ (
             const VertexT &src, VertexT &dest, const SizeT &edge_id,
             const VertexT &input_item, const SizeT &input_pos,
             SizeT &output_pos) -> bool
         {
-            // <TODO> Implement advance operation
+            SizeT num_neighbors = graph.GetNeighborListLength(src);
+            SizeT src_offset    = graph.GetNeighborListOffset(src);
+            for(SizeT neib_offset = 0; neib_offset < num_neighbors; neib_offset++) {
+              VertexT neib = graph.GetEdgeDest(src_offset + neib_offset);
 
-            // Mark src and dest as visited
-            atomicMax(visited + src, 1);
-            auto dest_visited = atomicMax(visited + dest, 1);
+              if(neib != dest) {
+                ValueT edge_weight = (ValueT)1.0; // Could do more complex functions of edge weights
+                SizeT edge_idx = (SizeT)neib * graph.nodes + (SizeT)dest;
+                atomicAdd(projections + edge_idx, edge_weight);
+              }
+            }
 
-            // Increment degree of src
-            atomicAdd(degrees + src, 1);
-
-            // Add dest to queue if previously unsen
-            return dest_visited == 0;
-
-            // </TODO>
+            return false;
         };
 
         // filter operation
         auto filter_op = [
-            // <TODO> pass data to lambda
-            // </TODO>
         ] __host__ __device__ (
             const VertexT &src, VertexT &dest, const SizeT &edge_id,
             const VertexT &input_item, const SizeT &input_pos,
             SizeT &output_pos) -> bool
         {
-            // <TODO> implement filter operation
-            return true;
-            // </TODO>
+            return false;
         };
 
         // --
@@ -256,7 +233,7 @@ public:
      * @brief proj constructor
      */
     Enactor() :
-        BaseEnactor("Template"),
+        BaseEnactor("graph_projections"),
         problem    (NULL  )
     {
         // <TODO> change according to algorithmic needs
@@ -346,29 +323,37 @@ public:
      * \return cudaError_t error message(s), if any
      */
     cudaError_t Reset(
-        // <TODO> problem specific data if necessary, eg
-        VertexT src = 0,
-        // </TODO>
         util::Location target = util::DEVICE)
     {
         typedef typename GraphT::GpT GpT;
         cudaError_t retval = cudaSuccess;
         GUARD_CU(BaseEnactor::Reset(target));
 
-        // <TODO> Initialize frontiers according to the algorithm:
-        // In this case, we add a single `src` to the frontier
+        SizeT num_nodes = this -> problem -> data_slices[0][0].sub_graph[0].nodes;
+
         for (int gpu = 0; gpu < this->num_gpus; gpu++) {
-           if ((this->num_gpus == 1) ||
-                (gpu == this->problem->org_graph->GpT::partition_table[src])) {
-               this -> thread_slices[gpu].init_size = 1;
+           if ((this->num_gpus == 1)) {
+           // if ((this->num_gpus == 1) ||
+           //      (gpu == this->problem->org_graph->GpT::partition_table[src])) {
+               this -> thread_slices[gpu].init_size = num_nodes;
                for (int peer_ = 0; peer_ < this -> num_gpus; peer_++) {
                    auto &frontier = this -> enactor_slices[gpu * this -> num_gpus + peer_].frontier;
-                   frontier.queue_length = (peer_ == 0) ? 1 : 0;
+                   frontier.queue_length = (peer_ == 0) ? num_nodes : 0;
                    if (peer_ == 0) {
-                       GUARD_CU(frontier.V_Q() -> ForEach(
-                           [src]__host__ __device__ (VertexT &v) {
-                           v = src;
-                       }, 1, target, 0));
+                      // Fill input frontier w/ all nodes
+                      util::Array1D<SizeT, VertexT> tmp;
+                      tmp.Allocate(num_nodes, target | util::HOST);
+                      for(SizeT i = 0; i < num_nodes; ++i) {
+                          tmp[i] = (VertexT)i;
+                      }
+                      GUARD_CU(tmp.Move(util::HOST, target));
+
+                      GUARD_CU(frontier.V_Q() -> ForEach(tmp,
+                          []__host__ __device__ (VertexT &v, VertexT &i) {
+                          v = i;
+                      }, num_nodes, target, 0));
+
+                      tmp.Release();
                    }
                }
            } else {
@@ -378,7 +363,6 @@ public:
                 }
            }
         }
-        // </TODO>
 
         GUARD_CU(BaseEnactor::Sync());
         return retval;
@@ -389,11 +373,7 @@ public:
 ...
      * \return cudaError_t error message(s), if any
      */
-    cudaError_t Enact(
-        // <TODO> problem specific data if necessary, eg
-        VertexT src = 0
-        // </TODO>
-    )
+    cudaError_t Enact()
     {
         cudaError_t retval = cudaSuccess;
         GUARD_CU(this -> Run_Threads(this));

--- a/gunrock/app/proj/proj_problem.cuh
+++ b/gunrock/app/proj/proj_problem.cuh
@@ -1,0 +1,368 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * proj_problem.cuh
+ *
+ * @brief GPU Storage management Structure for proj Problem Data
+ */
+
+#pragma once
+
+#include <gunrock/app/problem_base.cuh>
+
+namespace gunrock {
+namespace app {
+namespace proj {
+
+
+/**
+ * @brief Speciflying parameters for proj Problem
+ * @param  parameters  The util::Parameter<...> structure holding all parameter info
+ * \return cudaError_t error message(s), if any
+ */
+cudaError_t UseParameters_problem(
+    util::Parameters &parameters)
+{
+    cudaError_t retval = cudaSuccess;
+
+    GUARD_CU(gunrock::app::UseParameters_problem(parameters));
+
+    // <TODO> Add problem specific command-line parameter usages here, e.g.:
+    // GUARD_CU(parameters.Use<bool>(
+    //    "mark-pred",
+    //    util::OPTIONAL_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
+    //    false,
+    //    "Whether to mark predecessor info.",
+    //    __FILE__, __LINE__));
+    // </TODO>
+
+    return retval;
+}
+
+/**
+ * @brief Template Problem structure.
+ * @tparam _GraphT  Type of the graph
+ * @tparam _FLAG    Problem flags
+ */
+template <
+    typename _GraphT,
+    ProblemFlag _FLAG = Problem_None>
+struct Problem : ProblemBase<_GraphT, _FLAG>
+{
+    typedef _GraphT GraphT;
+    static const ProblemFlag FLAG = _FLAG;
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::ValueT  ValueT;
+    typedef typename GraphT::SizeT   SizeT;
+    typedef typename GraphT::CsrT    CsrT;
+    typedef typename GraphT::GpT     GpT;
+
+    typedef ProblemBase   <GraphT, FLAG> BaseProblem;
+    typedef DataSliceBase <GraphT, FLAG> BaseDataSlice;
+
+    // ----------------------------------------------------------------
+    // Dataslice structure
+
+    /**
+     * @brief Data structure containing problem specific data on indivual GPU.
+     */
+    struct DataSlice : BaseDataSlice
+    {
+        // <TODO> add problem specific storage arrays:
+        util::Array1D<SizeT, ValueT> degrees;
+        util::Array1D<SizeT, int> visited;
+        // </TODO>
+
+        /*
+         * @brief Default constructor
+         */
+        DataSlice() : BaseDataSlice()
+        {
+            // <TODO> name of the problem specific arrays:
+            degrees.SetName("degrees");
+            visited.SetName("visited");
+            // </TODO>
+        }
+
+        /*
+         * @brief Default destructor
+         */
+        virtual ~DataSlice() { Release(); }
+
+        /*
+         * @brief Releasing allocated memory space
+         * @param[in] target      The location to release memory from
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Release(util::Location target = util::LOCATION_ALL)
+        {
+            cudaError_t retval = cudaSuccess;
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx));
+
+            // <TODO> Release problem specific data, e.g.:
+            GUARD_CU(degrees.Release(target));
+            GUARD_CU(visited.Release(target));
+            // </TODO>
+
+            GUARD_CU(BaseDataSlice ::Release(target));
+            return retval;
+        }
+
+        /**
+         * @brief initializing sssp-specific data on each gpu
+         * @param     sub_graph   Sub graph on the GPU.
+         * @param[in] gpu_idx     GPU device index
+         * @param[in] target      Targeting device location
+         * @param[in] flag        Problem flag containling options
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Init(
+            GraphT        &sub_graph,
+            int            num_gpus,
+            int            gpu_idx,
+            util::Location target,
+            ProblemFlag    flag)
+        {
+            cudaError_t retval  = cudaSuccess;
+
+            GUARD_CU(BaseDataSlice::Init(sub_graph, num_gpus, gpu_idx, target, flag));
+
+            // <TODO> allocate problem specific data here, e.g.:
+            GUARD_CU(degrees.Allocate(sub_graph.nodes, target));
+            GUARD_CU(visited.Allocate(sub_graph.nodes, target));
+            // </TODO>
+
+            if (target & util::DEVICE) {
+                // <TODO> move sub-graph used by the problem onto GPU,
+                GUARD_CU(sub_graph.CsrT::Move(util::HOST, target, this -> stream));
+                // </TODO>
+            }
+            return retval;
+        }
+
+        /**
+         * @brief Reset problem function. Must be called prior to each run.
+         * @param[in] target      Targeting device location
+         * \return    cudaError_t Error message(s), if any
+         */
+        cudaError_t Reset(util::Location target = util::DEVICE)
+        {
+            cudaError_t retval = cudaSuccess;
+            SizeT nodes = this -> sub_graph -> nodes;
+
+            // Ensure data are allocated
+            // <TODO> ensure size of problem specific data:
+            GUARD_CU(degrees.EnsureSize_(nodes, target));
+            GUARD_CU(visited.EnsureSize_(nodes, target));
+            // </TODO>
+
+            // Reset data
+            // <TODO> reset problem specific data, e.g.:
+            GUARD_CU(degrees.ForEach([]__host__ __device__ (ValueT &x){
+               x = (ValueT)0;
+            }, nodes, target, this -> stream));
+
+            GUARD_CU(visited.ForEach([]__host__ __device__ (int &x){
+               x = (int)0;
+            }, nodes, target, this -> stream));
+            // </TODO>
+
+            return retval;
+        }
+    }; // DataSlice
+
+    // Set of data slices (one for each GPU)
+    util::Array1D<SizeT, DataSlice> *data_slices;
+
+    // ----------------------------------------------------------------
+    // Problem Methods
+
+    /**
+     * @brief proj default constructor
+     */
+    Problem(
+        util::Parameters &_parameters,
+        ProblemFlag _flag = Problem_None) :
+        BaseProblem(_parameters, _flag),
+        data_slices(NULL) {}
+
+    /**
+     * @brief proj default destructor
+     */
+    virtual ~Problem() { Release(); }
+
+    /*
+     * @brief Releasing allocated memory space
+     * @param[in] target      The location to release memory from
+     * \return    cudaError_t Error message(s), if any
+     */
+    cudaError_t Release(util::Location target = util::LOCATION_ALL)
+    {
+        cudaError_t retval = cudaSuccess;
+        if (data_slices == NULL) return retval;
+        for (int i = 0; i < this->num_gpus; i++)
+            GUARD_CU(data_slices[i].Release(target));
+
+        if ((target & util::HOST) != 0 &&
+            data_slices[0].GetPointer(util::DEVICE) == NULL)
+        {
+            delete[] data_slices; data_slices=NULL;
+        }
+        GUARD_CU(BaseProblem::Release(target));
+        return retval;
+    }
+
+    /**
+     * @brief Copy result distancess computed on GPUs back to host-side arrays.
+...
+     * \return     cudaError_t Error message(s), if any
+     */
+    cudaError_t Extract(
+        // <TODO> problem specific data to extract
+        ValueT *h_degrees,
+        // </TODO>
+        util::Location target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        SizeT nodes = this -> org_graph -> nodes;
+
+        if (this-> num_gpus == 1) {
+            auto &data_slice = data_slices[0][0];
+
+            // Set device
+            if (target == util::DEVICE) {
+                GUARD_CU(util::SetDevice(this->gpu_idx[0]));
+
+                // <TODO> extract the results from single GPU, e.g.:
+                GUARD_CU(data_slice.degrees.SetPointer(h_degrees, nodes, util::HOST));
+                GUARD_CU(data_slice.degrees.Move(util::DEVICE, util::HOST));
+                // </TODO>
+            } else if (target == util::HOST) {
+                // <TODO> extract the results from single CPU, e.g.:
+                GUARD_CU(data_slice.degrees.ForEach(h_degrees,
+                   []__host__ __device__ (const ValueT &device_val, ValueT &host_val){
+                       host_val = device_val;
+                   }, nodes, util::HOST));
+                // </TODO>
+            }
+        } else { // num_gpus != 1
+
+            // ============ INCOMPLETE TEMPLATE - MULTIGPU ============
+
+            // // TODO: extract the results from multiple GPUs, e.g.:
+            // // util::Array1D<SizeT, ValueT *> th_distances;
+            // // th_distances.SetName("bfs::Problem::Extract::th_distances");
+            // // GUARD_CU(th_distances.Allocate(this->num_gpus, util::HOST));
+
+            // for (int gpu = 0; gpu < this->num_gpus; gpu++)
+            // {
+            //     auto &data_slice = data_slices[gpu][0];
+            //     if (target == util::DEVICE)
+            //     {
+            //         GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+            //         // GUARD_CU(data_slice.distances.Move(util::DEVICE, util::HOST));
+            //     }
+            //     // th_distances[gpu] = data_slice.distances.GetPointer(util::HOST);
+            // } //end for(gpu)
+
+            // for (VertexT v = 0; v < nodes; v++)
+            // {
+            //     int gpu = this -> org_graph -> GpT::partition_table[v];
+            //     VertexT v_ = v;
+            //     if ((GraphT::FLAG & gunrock::partitioner::Keep_Node_Num) != 0)
+            //         v_ = this -> org_graph -> GpT::convertion_table[v];
+
+            //     // h_distances[v] = th_distances[gpu][v_];
+            // }
+
+            // // GUARD_CU(th_distances.Release());
+        }
+
+        return retval;
+    }
+
+    /**
+     * @brief initialization function.
+     * @param     graph       The graph that SSSP processes on
+     * @param[in] Location    Memory location to work on
+     * \return    cudaError_t Error message(s), if any
+     */
+    cudaError_t Init(
+            GraphT           &graph,
+            util::Location    target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+        GUARD_CU(BaseProblem::Init(graph, target));
+        data_slices = new util::Array1D<SizeT, DataSlice>[this->num_gpus];
+
+        // <TODO> get problem specific flags from parameters, e.g.:
+        // if (this -> parameters.template Get<bool>("mark-pred"))
+        //    this -> flag = this -> flag | Mark_Predecessors;
+        // </TODO>
+
+        for (int gpu = 0; gpu < this->num_gpus; gpu++) {
+            data_slices[gpu].SetName("data_slices[" + std::to_string(gpu) + "]");
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+
+            GUARD_CU(data_slices[gpu].Allocate(1, target | util::HOST));
+
+            auto &data_slice = data_slices[gpu][0];
+            GUARD_CU(data_slice.Init(
+                this -> sub_graphs[gpu],
+                this -> num_gpus,
+                this -> gpu_idx[gpu],
+                target,
+                this -> flag
+            ));
+        }
+
+        return retval;
+    }
+
+    /**
+     * @brief Reset problem function. Must be called prior to each run.
+     * @param[in] src      Source vertex to start.
+     * @param[in] location Memory location to work on
+     * \return cudaError_t Error message(s), if any
+     */
+    cudaError_t Reset(
+        // <TODO> problem specific data if necessary, eg
+        // VertexT src,
+        // </TODO>
+        util::Location target = util::DEVICE)
+    {
+        cudaError_t retval = cudaSuccess;
+
+        // Reset data slices
+        for (int gpu = 0; gpu < this->num_gpus; ++gpu) {
+            if (target & util::DEVICE)
+                GUARD_CU(util::SetDevice(this->gpu_idx[gpu]));
+            GUARD_CU(data_slices[gpu] -> Reset(target));
+            GUARD_CU(data_slices[gpu].Move(util::HOST, target));
+        }
+
+        // <TODO> Additional problem specific initialization
+        // </TODO>
+
+        GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
+        return retval;
+    }
+};
+
+} //namespace Template
+} //namespace app
+} //namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/gunrock/app/proj/proj_problem.cuh
+++ b/gunrock/app/proj/proj_problem.cuh
@@ -132,7 +132,6 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
         {
             cudaError_t retval = cudaSuccess;
             SizeT nodes = this -> sub_graph -> nodes;
-            printf("Reset::nodes=%d\n", nodes);
 
             // Ensure data are allocated
             GUARD_CU(projections.EnsureSize_(nodes * nodes, target));
@@ -204,8 +203,6 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
 
             // Set device
             if (target == util::DEVICE) {
-                printf("Extract: target == util::DEVICE\n");
-                printf("Extract: nodes=%d\n", nodes);
                 GUARD_CU(util::SetDevice(this->gpu_idx[0]));
                 GUARD_CU(data_slice.projections.SetPointer(h_projections, nodes * nodes, util::HOST));
                 GUARD_CU(data_slice.projections.Move(util::DEVICE, util::HOST));
@@ -214,7 +211,6 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
                 GUARD_CU(data_slice.projections.ForEach(h_projections,
                    []__host__ __device__ (const ValueT &device_val, ValueT &host_val){
                        host_val = device_val;
-                       printf("host_val=%d | device_val=%d", host_val, device_val);
                    }, nodes * nodes, util::HOST));
             }
         } else { // num_gpus != 1

--- a/gunrock/app/proj/proj_test.cuh
+++ b/gunrock/app/proj/proj_test.cuh
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * proj_test.cu
+ *
+ * @brief Test related functions for proj
+ */
+
+#pragma once
+
+namespace gunrock {
+namespace app {
+namespace proj {
+
+
+/******************************************************************************
+ * Template Testing Routines
+ *****************************************************************************/
+
+/**
+ * @brief Simple CPU-based reference proj ranking implementations
+ * @tparam      GraphT        Type of the graph
+ * @tparam      ValueT        Type of the values
+ * @param[in]   graph         Input graph
+...
+ * @param[in]   quiet         Whether to print out anything to stdout
+ */
+template <typename GraphT>
+double CPU_Reference(
+    const GraphT &graph,
+    typename GraphT::ValueT *projections,
+    bool quiet)
+{
+    typedef typename GraphT::SizeT SizeT;
+
+    util::CpuTimer cpu_timer;
+    cpu_timer.Start();
+
+    for(SizeT node = i; i < graph.nodes; )
+    // <TODO>
+    // implement CPU reference implementation
+    for(SizeT v = 0; v < graph.nodes; ++v) {
+        degrees[v] = graph.row_offsets[v + 1] - graph.row_offsets[v];
+    }
+    // </TODO>
+
+    cpu_timer.Stop();
+    float elapsed = cpu_timer.ElapsedMillis();
+    return elapsed;
+}
+
+/**
+ * @brief Validation of proj results
+ * @tparam     GraphT        Type of the graph
+ * @tparam     ValueT        Type of the values
+ * @param[in]  parameters    Excution parameters
+ * @param[in]  graph         Input graph
+...
+ * @param[in]  verbose       Whether to output detail comparsions
+ * \return     GraphT::SizeT Number of errors
+ */
+template <typename GraphT>
+typename GraphT::SizeT Validate_Results(
+             util::Parameters &parameters,
+             GraphT           &graph,
+             typename GraphT::ValueT *h_degrees,
+             typename GraphT::ValueT *ref_degrees,
+             bool verbose = true)
+{
+    typedef typename GraphT::VertexT VertexT;
+    typedef typename GraphT::SizeT   SizeT;
+
+    SizeT num_errors = 0;
+    bool quiet = parameters.Get<bool>("quiet");
+
+    // <TODO> result validation and display
+    for(SizeT v = 0; v < graph.nodes; ++v) {
+        printf("%d %d %d\n", v, h_degrees[v], ref_degrees[v]);
+    }
+    // </TODO>
+
+    if(num_errors == 0) {
+       util::PrintMsg(std::to_string(num_errors) + " errors occurred.", !quiet);
+    }
+
+    return num_errors;
+}
+
+} // namespace Template
+} // namespace app
+} // namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:

--- a/tests/proj/Makefile
+++ b/tests/proj/Makefile
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------
+# Gunrock -- Fast and Efficient GPU Graph Library
+# ----------------------------------------------------------------
+# This source code is distributed under the terms of LICENSE.TXT
+# in the root directory of this source distribution.
+# ----------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# (make test) Test driver for ALGO
+#-------------------------------------------------------------------------------
+
+include ../BaseMakefile.mk
+ALGO = proj
+EXEC = bin/test_$(ALGO)_$(NVCC_VERSION)_$(ARCH_SUFFIX)
+
+test: $(EXEC)
+
+$(EXEC) : test_$(ALGO).cu $(DEPS)
+	mkdir -p bin
+	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
+
+a : test_$(ALGO).cu $(DEPS)
+	mkdir -p bin
+	rm -f $(EXEC)
+	$(NVCC) $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3 > a.txt 2>&1 || true
+	grep rror: a.txt; grep arn a.txt
+
+.DEFAULT_GOAL := test

--- a/tests/proj/test.sh
+++ b/tests/proj/test.sh
@@ -2,5 +2,6 @@
 
 # test.sh
 
-./bin/test_proj_9.1_x86_64 --graph-type market --graph-file ../../dataset/small/chesapeake.mtx --seed 456
+# ./bin/test_proj_9.1_x86_64 --graph-type market --graph-file ../../dataset/small/chesapeake.mtx --seed 456
 
+./bin/test_proj_9.1_x86_64 --graph-type market --graph-file sample.mtx --undirected=0

--- a/tests/proj/test.sh
+++ b/tests/proj/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# test.sh
+
+./bin/test_proj_9.1_x86_64 --graph-type market --graph-file ../../dataset/small/chesapeake.mtx --seed 456
+

--- a/tests/proj/test.sh
+++ b/tests/proj/test.sh
@@ -2,6 +2,6 @@
 
 # test.sh
 
-# ./bin/test_proj_9.1_x86_64 --graph-type market --graph-file ../../dataset/small/chesapeake.mtx --seed 456
+./bin/test_proj_9.1_x86_64 --graph-type market --graph-file ../../dataset/small/chesapeake.mtx --seed 456
 
-./bin/test_proj_9.1_x86_64 --graph-type market --graph-file sample.mtx --undirected=0
+# ./bin/test_proj_9.1_x86_64 --graph-type market --graph-file sample.mtx --undirected=0

--- a/tests/proj/test_proj.cu
+++ b/tests/proj/test_proj.cu
@@ -12,7 +12,6 @@
  * @brief Simple test driver program for Gunrock template.
  */
 
-#include <iostream>
 #include <gunrock/app/proj/proj_app.cu>
 #include <gunrock/app/test_base.cuh>
 

--- a/tests/proj/test_proj.cu
+++ b/tests/proj/test_proj.cu
@@ -1,0 +1,124 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * test_proj.cu
+ *
+ * @brief Simple test driver program for Gunrock template.
+ */
+
+#include <gunrock/app/proj/proj_app.cu>
+#include <gunrock/app/test_base.cuh>
+
+using namespace gunrock;
+
+namespace APP_NAMESPACE = app::proj;
+
+/******************************************************************************
+* Main
+******************************************************************************/
+
+/**
+ * @brief Enclosure to the main function
+ */
+struct main_struct
+{
+    /**
+     * @brief the actual main function, after type switching
+     * @tparam VertexT    Type of vertex identifier
+     * @tparam SizeT      Type of graph size, i.e. type of edge identifier
+     * @tparam ValueT     Type of edge values
+     * @param  parameters Command line parameters
+     * @param  v,s,val    Place holders for type deduction
+     * \return cudaError_t error message(s), if any
+     */
+    template <
+        typename VertexT, // Use int as the vertex identifier
+        typename SizeT,   // Use int as the graph size type
+        typename ValueT>  // Use int as the value type
+    cudaError_t operator()(util::Parameters &parameters,
+        VertexT v, SizeT s, ValueT val)
+    {
+        // CLI parameters
+        bool quick = parameters.Get<bool>("quick");
+        bool quiet = parameters.Get<bool>("quiet");
+
+        typedef typename app::TestGraph<VertexT, SizeT, ValueT,
+            graph::HAS_EDGE_VALUES | graph::HAS_CSR>
+            GraphT;
+
+        cudaError_t retval = cudaSuccess;
+        util::CpuTimer cpu_timer;
+        GraphT graph;
+
+        cpu_timer.Start();
+        GUARD_CU(graphio::LoadGraph(parameters, graph));
+        cpu_timer.Stop();
+        parameters.Set("load-time", cpu_timer.ElapsedMillis());
+
+        ValueT *ref_projection;
+
+        if (!quick) {
+            ref_projection = new ValueT[graph.nodes * graph.nodes];
+
+            // If not in `quick` mode, compute CPU reference implementation
+            util::PrintMsg("__________________________", !quiet);
+
+            float elapsed = app::proj::CPU_Reference(
+                graph.csr(),
+                ref_projection,
+                quiet);
+
+            util::PrintMsg("--------------------------\n Elapsed: "
+                + std::to_string(elapsed), !quiet);
+        }
+
+        std::vector<std::string> switches{"advance-mode"};
+        GUARD_CU(app::Switch_Parameters(parameters, graph, switches,
+            [
+                ref_projection
+            ](util::Parameters &parameters, GraphT &graph)
+            {
+                return app::proj::RunTests(parameters, graph, ref_projection, util::DEVICE);
+            }));
+
+        if (!quick) {
+            delete[] ref_projection; ref_projection = NULL;
+        }
+        return retval;
+    }
+};
+
+int main(int argc, char** argv)
+{
+    cudaError_t retval = cudaSuccess;
+    util::Parameters parameters("test proj");
+    GUARD_CU(graphio::UseParameters(parameters));
+    GUARD_CU(app::proj::UseParameters(parameters));
+    GUARD_CU(app::UseParameters_test(parameters));
+    GUARD_CU(parameters.Parse_CommandLine(argc, argv));
+    if (parameters.Get<bool>("help"))
+    {
+        parameters.Print_Help();
+        return cudaSuccess;
+    }
+    GUARD_CU(parameters.Check_Required());
+
+    // TODO: change available graph types, according to requirements
+    return app::Switch_Types<
+        app::VERTEXT_U32B | app::VERTEXT_U64B |
+        app::SIZET_U32B | app::SIZET_U64B |
+        app::VALUET_U32B | app::DIRECTED>
+        (parameters, main_struct());
+}
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:


### PR DESCRIPTION
## Graph Projections

Given a directed graph `G`, `GraphProjections` outputs a graph `Gp` s.t. there is an edge `(u,v)` in `Gp` iff there are edges `(t,u)` and `(t,v)` in `G`.

#### Reference implementations
 - (C++) https://gitlab.hiveprogram.com/jfiroz/graph_projection
 - (pygunrock) https://github.com/bkj/pygunrock/blob/master/apps/graph_projections.py

#### Issues
 - It's a little unclear what the intended use case/topology for this is.  The HIVE slides suggest it's a bipartite graph w/ node sets `U` and `V` s.t. `|V| >> |U|`.  However, the reference implementation is designed to work for arbitrary graphs.  The C++ version above has a flag for bipartite vs. unipartite graphs, but I'm not sure it behaves as desired (I have a question out to the author).
 - Often these projected graphs get _very_ dense.  With large graphs, there's a risk that we run out of GPU memory: graph projections can increase the number of edges in a graph by > 4 orders of magnitude (!)  How should we deal with this?
 - Right now, we're allocating a dense `|V|x|V|` array to store the projected edges -- this is clearly not memory efficient, and should be replaced if we want to support large graphs.

#### TODO
 - [x]  `proj` should _only_ take directed graphs -- how do we set that to be default? (cc @sgpyc)
 - [ ]  (optional) Implement additional weighting functions

[1] https://arxiv.org/pdf/1611.02756.pdf