### PR TITLE
[bug-fix] gtest and gmock working again with dev branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ else (WARNING_DEP_FLAG)
 endif (WARNING_DEP_FLAG)
 # end /* Suppress "deprecated auto_ptr" warnings caused by moderngpu */
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
+
 option(CMAKE_VERBOSE_MAKEFILE ON)
 
 # begin /* Find and set CUDA arch */


### PR DESCRIPTION
Also tested #379 in `dev` branch, really sweet speed-ups with using `ninja` instead of `make`. Auto generation of `ninja.builds` using `cmake .. -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja`. 🎉 