### PR TITLE
Fix build on Ubuntu 18.04.1 LTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,8 @@ endif (CUDA_VERBOSE_PTXAS)
 # end /* Configure GUNROCK build options */
 
 # c++11 is required
-set(CUDA_NVCC_FLAGS -std=c++11)
+# Already set above. Causes build error on Ubuntu 18.04.1 LTS 
+#set(CUDA_NVCC_FLAGS -std=c++11)
 set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_curand_LIBRARY})
 
 if(GUNROCK_BUILD_LIB)

--- a/examples/sm/test_sm.cu
+++ b/examples/sm/test_sm.cu
@@ -359,7 +359,7 @@ int main_Value(CommandLineArgs *args, int graph_args)
 {
 // can be disabled to reduce compile time
     if (args -> CheckCmdLineFlag("64bit-Value"))
-        return main_<VertexId, SizeT, unsigned long long      >(args, graph_args);
+        return main_<VertexId, SizeT, long long      >(args, graph_args);
     else
         return main_<VertexId, SizeT,  int      >(args, graph_args);
 }


### PR DESCRIPTION
@neoblizz 

The ` -std=c++11` parameter was being passed to nvcc multiple times and gunrock would not build.

`test_sm.cu` was passing an `unsigned long long` to the abs function. This is ambiguous because abs expects a signed value.