### PR TITLE
Changing how Makefile gets GIT_SHA1, now it doesn't need CMakeLists.t…

### DIFF
--- a/gunrock/util/gitsha1make.c
+++ b/gunrock/util/gitsha1make.c
@@ -1,0 +1,5 @@
+#ifndef GIT_SHA1
+  #define GIT_SHA1 "GIT-SHA-NOT-FOUND"
+#endif
+
+const char g_GIT_SHA1[] = GIT_SHA1;

--- a/tests/BaseMakefile.mk
+++ b/tests/BaseMakefile.mk
@@ -83,7 +83,7 @@ INC = $(CUDA_INC) $(OMP_INC) $(MGPU_INC) $(CUB_INC) $(BOOST_INC) -I.. -I../.. $(
 # Defines
 #-------------------------------------------------------------------------------
 
-DEFINES =
+DEFINES = -DGIT_SHA1="\"$(shell git rev-parse HEAD)\""
 
 #-------------------------------------------------------------------------------
 # Compiler Flags
@@ -125,7 +125,7 @@ EXTRA_SOURCE_ = ../../gunrock/util/str_to_T.cu \
 	../../gunrock/util/error_utils.cu \
 	../../externals/moderngpu/src/mgpucontext.cu \
 	../../externals/moderngpu/src/mgpuutil.cpp \
-	../../gunrock/util/gitsha1.c
+	../../gunrock/util/gitsha1make.c
 
 ifeq (DARWIN, $(findstring DARWIN, $(OSUPPER)))
     EXTRA_SOURCE = $(EXTRA_SOURCE_) \


### PR DESCRIPTION
…xt to work. Here's an example of Geolocation:

```
mosama@mario:~/forks/neo/gunrock/tests/geo$ ./bin/test_geo_10.0_x86_64 market ./_data/sample/geolocation.mtx --labels-file=./_data/sample/locations.labels --json
Loading Matrix-market coordinate-formatted graph ...
  Reading meta data from ./_data/sample/geolocation.mtx.meta
  Reading edge lists from ./_data/sample/geolocation.mtx.coo_edge_pairs
  Assigning 1 to all 170 edges
  Substracting 1 from node Ids...
  Edge doubleing: 170 -> 340 edges
  graph loaded as COO in 0.056150s.
Converting 39 vertices, 340 directed edges ( ordered tuples) to CSR format...Done (0s).
Degree Histogram (39 vertices, 340 edges):
    Degree 0: 0 (0.000000 %)
    Degree 2^0: 0 (0.000000 %)
    Degree 2^1: 1 (2.564103 %)
    Degree 2^2: 22 (56.410256 %)
    Degree 2^3: 13 (33.333333 %)
    Degree 2^4: 2 (5.128205 %)
    Degree 2^5: 1 (2.564103 %)

Labels File Input: ./_data/sample/locations.labels
Loading Labels into an array ...
Reading from ./_data/sample/locations.labels:
  Parsing LABELS
 (39 nodes)
__________________________
______ CPU Reference _____
--------------------------
 Elapsed: 11.148214
__________________________
==============================================
 advance-mode=LB
Number of iterations: 3
Initializing problem ...
Number of nodes for allocation: 39
Initializing enactor ...
Using advance mode LB
Using filter mode CULL
__________________________
0        0       0       queue3          oversize :      234 ->  342
0        0       0       queue3          oversize :      234 ->  342
--------------------------
Run 0 elapsed: 0.380039, #iterations = 3
Node [ 0 ]: Predicted = < 37.744907 , -122.009430 > Reference = < 37.744907 , -122.009430 >
...
0 errors occurred.
[geolocation] finished.
 avg. elapsed: 0.380039 ms
 iterations: 3
 min. elapsed: 0.380039 ms
 max. elapsed: 0.380039 ms
 load time: 187.816 ms
 preprocess time: 407.559000 ms
 postprocess time: 0.670195 ms
 total time: 408.864975 ms
{
    "engine": "Gunrock",
    "command-line": "./bin/test_geo_10.0_x86_64 market ./_data/sample/geolocation.mtx --labels-file=./_data/sample/locations.labels --json",
    "compiler": "Gnu GCC C/C++",
    "compiler-version": 50400000,
    "time": "Wed Oct 31 11:59:48 2018\n",
    "gunrock-version": "0.4.0",
    "git-commit-sha": "b83435c68f52ea21865d434f1ce484d82c282e5a",
    "load-time": 187.8159942626953,
    "algorithm": "geolocation",
    "64bit-SizeT": "0",
    "64bit-ValueT": "0",
    "64bit-VertexT": "0",
    "advance-mode": [
        "LB"
    ],
    "binary-prefix": "",
    "communicate-latency": 0,
    "communicate-multipy": 1.0,
    "dataset": "locations",
    "debug": false,
    "device": [
        0
    ],
    "edge-value-min": 0.0,
    "edge-value-range": 64.0,
    "edge-value-seed": 0,
    "expand-latency": 0,
    "filter-mode": "CULL",
    "fullqueue-latency": 0,
    "geo-complete": false,
    "geo-iter": 3,
    "graph-edgefactor": 48.0,
    "graph-edges": 49152,
    "graph-file": "./_data/sample/geolocation.mtx",
    "graph-nodes": 1024,
    "graph-scale": 10,
    "graph-seed": 0,
    "graph-type": "market",
    "help": false,
    "json": true,
    "jsondir": "",
    "jsonfile": "",
    "labels-file": "./_data/sample/locations.labels",
    "load-time": 187.8159942626953,
    "makeout-latency": 0,
    "max-grid-size": 0,
    "num-runs": 1,
    "partition-factor": 0.5,
    "partition-method": "random",
    "partition-seed": 0,
    "preprocess-time": 0.0,
    "queue-factor": [
        6.0
    ],
    "quick": false,
    "quiet": false,
    "random-edge-values": false,
    "read-from-binary": true,
    "remove-duplicate-edges": true,
    "remove-self-loops": true,
    "rgg-thfactor": 0.55,
    "rgg-threshold": 0.0,
    "rmat-a": 0.57,
    "rmat-b": 0.19,
    "rmat-c": 0.19,
    "rmat-d": 0.05,
    "size-check": true,
    "spatial-iter": 1000,
    "srcs": [
        0
    ],
    "store-to-binary": true,
    "subqueue-latency": 0,
    "sw-k": 6,
    "sw-p": 0.0,
    "trans-factor": 1.0,
    "undirected": "0",
    "v": false,
    "validation": "last",
    "vertex-start-from-zero": true,
    "setdev-degree": 6.223675727844238,
    "num-vertices": 39,
    "num-edges": 340,
    "elapsed": 0.3800392150878906,
    "average-duty": 0.0,
    "search-depth": 3,
    "edges-queued": 0,
    "nodes-queued": 0,
    "nodes-visited": 0,
    "edges-visited": 0,
    "nodes-redundance": 0.0,
    "edges-redundance": 0.0,
    "m-teps": 0.0,
    "process-times": [
        0.3800392150878906
    ],
    "min-process-time": 0.3800392150878906,
    "max-process-time": 0.3800392150878906,
    "postprocess-time": 0.6701946258544922,
    "total-time": 408.86497497558596
```