### PR TITLE
Update the max flow algorithm

### DIFF
--- a/gunrock/app/mf/mf_app.cu
+++ b/gunrock/app/mf/mf_app.cu
@@ -143,6 +143,10 @@ cudaError_t RunTests(util::Parameters &parameters, GraphT &graph,
     cpu_timer.Stop();
     info.CollectSingleRun(cpu_timer.ElapsedMillis());
 
+//    fprintf(stderr, "-----------------------------------\nRun %d, elapsed: %lf ms, #iterations = %d\n", \
+		    run_num, cpu_timer.ElapsedMillis(), enactor.enactor_slices[0].enactor_stats.iteration);
+
+    fprintf(stderr, "GPU Elapsed: %lf ms, ", cpu_timer.ElapsedMillis());
     util::PrintMsg(
         "-----------------------------------\nRun " + std::to_string(run_num) +
             ", elapsed: " + std::to_string(cpu_timer.ElapsedMillis()) +

--- a/gunrock/app/mf/mf_problem.cuh
+++ b/gunrock/app/mf/mf_problem.cuh
@@ -80,7 +80,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
     VertexT tail_;
 
     util::Array1D<SizeT, bool> reachabilities;
-    util::Array1D<SizeT, VertexT> queue;
+    util::Array1D<SizeT, VertexT> queue0;
+    util::Array1D<SizeT, VertexT> queue1;
     util::Array1D<SizeT, bool> mark;
 
     VertexT source;  // source vertex
@@ -112,7 +113,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
       tail.SetName("tail");
 
       reachabilities.SetName("reachabilities");
-      queue.SetName("queue");
+      queue0.SetName("queue0");
+      queue1.SetName("queue1");
       mark.SetName("mark");
       changed.SetName("changed");
     }
@@ -144,7 +146,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
       GUARD_CU(tail.Release(target));
 
       GUARD_CU(reachabilities.Release(target));
-      GUARD_CU(queue.Release(target));
+      GUARD_CU(queue0.Release(target));
+      GUARD_CU(queue1.Release(target));
       GUARD_CU(mark.Release(target));
 
       GUARD_CU(BaseDataSlice::Release(target));
@@ -190,7 +193,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
 
       GUARD_CU(reachabilities.Allocate(nodes_size, target));
 
-      GUARD_CU(queue.Allocate(nodes_size, target));
+      GUARD_CU(queue0.Allocate(nodes_size, target));
+      GUARD_CU(queue1.Allocate(nodes_size, target));
       GUARD_CU(mark.Allocate(nodes_size, target));
 
       GUARD_CU(changed.Allocate(1, util::HOST | target));
@@ -231,7 +235,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
       GUARD_CU(tail.EnsureSize_(1, target));
 
       GUARD_CU(reachabilities.EnsureSize_(nodes_size, target));
-      GUARD_CU(queue.EnsureSize_(nodes_size, target));
+      GUARD_CU(queue0.EnsureSize_(nodes_size, target));
+      GUARD_CU(queue1.EnsureSize_(nodes_size, target));
       GUARD_CU(mark.EnsureSize_(nodes_size, target));
 
       GUARD_CU(changed.EnsureSize_(1, target | util::HOST));

--- a/gunrock/app/mf/mf_test.cuh
+++ b/gunrock/app/mf/mf_test.cuh
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <queue>
+#include <map>
 
 namespace gunrock {
 namespace app {
@@ -210,12 +211,15 @@ void minCut(GraphT& graph, VertexT src, ValueT* flow, int* min_cut,
  *
  * \return     double      Time taken for the MF
  */
-template <typename VertexT, typename ValueT, typename GraphT>
-double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
-                     VertexT sin, ValueT& maxflow, VertexT* reverse,
-                     ValueT* flow) {
+template <typename VertexT, 
+	 typename ValueT, 
+	 typename GraphT,
+	 typename SizeT>
+double CPU_Reference(util::Parameters& parameters, GraphT& graph, 
+		std::map<std::pair<VertexT, VertexT>, SizeT>& edge_id,
+		VertexT src, VertexT sin, ValueT& maxflow, VertexT* reverse,
+                ValueT* flow) {
   debug_aml("CPU_Reference start\n");
-  typedef typename GraphT::SizeT SizeT;
   typedef typename GraphT::CsrT CsrT;
 
   double elapsed = 0;
@@ -266,7 +270,6 @@ double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
     for (auto e = e_start; e < e_end; ++e) {
       VertexT y = graph.CsrT::GetEdgeDest(e);
       ValueT cap = graph.CsrT::edge_values[e];
-      if (fabs(cap) <= 1e-12) continue;
       Traits::edge_descriptor e1, e2;
       bool in1, in2;
       tie(e1, in1) = add_edge(verts[x], verts[y], boost_graph);
@@ -300,16 +303,7 @@ double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
   //
   // Extracting results on CPU
   //
-  std::map<std::pair<VertexT, VertexT>, VertexT> edge_id;
-  for (VertexT x = 0; x < graph.nodes; ++x) {
-	  auto e_start = graph.CsrT::GetNeighborListOffset(x);
-	  auto num_neighbors = graph.CsrT::GetNeighborListLength(x);
-	  auto e_end = e_start + num_neighbors;
-	  for (VertexT e = e_start; e < e_end; ++e) {
-		  VertexT y = graph.CsrT::GetEdgeDest(e);
-		  edge_id[std::make_pair(x, y)] = e;
-	  }
-  }
+
   typename graph_traits<Graph>::vertex_iterator u_it, u_end;
   typename graph_traits<Graph>::out_edge_iterator e_it, e_end;
   for (tie(u_it, u_end) = vertices(boost_graph); u_it != u_end; ++u_it) {

--- a/gunrock/app/mf/mf_test.cuh
+++ b/gunrock/app/mf/mf_test.cuh
@@ -25,6 +25,7 @@
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/edmonds_karp_max_flow.hpp>
+#include <boost/graph/push_relabel_max_flow.hpp>
 #include <boost/graph/boykov_kolmogorov_max_flow.hpp>
 #include <boost/graph/read_dimacs.hpp>
 #include <iostream>
@@ -226,11 +227,17 @@ double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
 
   // Prepare Boost Datatype and Data structure
   typedef adjacency_list_traits<vecS, vecS, directedS> Traits;
-  typedef adjacency_list<
-      vecS, vecS, directedS, property<vertex_name_t, std::string>,
-      property<edge_capacity_t, ValueT,
-               property<edge_residual_capacity_t, ValueT,
-                        property<edge_reverse_t, Traits::edge_descriptor>>>>
+  typedef adjacency_list<vecS, vecS, directedS, 
+	  //property<vertex_name_t, std::string>,
+	  property < vertex_name_t, std::string,
+	  property < vertex_index_t, long,
+	  property < vertex_color_t, boost::default_color_type,
+	  property < vertex_distance_t, long,
+	  property < vertex_predecessor_t, Traits::edge_descriptor > > > > >,
+	  
+    	  property<edge_capacity_t, ValueT,
+	  property<edge_residual_capacity_t, ValueT,
+	  property<edge_reverse_t, Traits::edge_descriptor>>>>
       Graph;
 
   Graph boost_graph;
@@ -281,40 +288,37 @@ double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
 
   util::CpuTimer cpu_timer;
   cpu_timer.Start();
-  maxflow = edmonds_karp_max_flow(boost_graph, source, sink);
-  //maxflow = boykov_kolmogorov_max_flow(boost_graph, source, sink);
+  //maxflow = edmonds_karp_max_flow(boost_graph, source, sink);
+  //maxflow = push_relabel_max_flow(boost_graph, source, sink);
+  maxflow = boykov_kolmogorov_max_flow(boost_graph, source, sink);
   cpu_timer.Stop();
   elapsed = cpu_timer.ElapsedMillis();
 
   fprintf(stderr, "CPU Elapsed: %lf ms, cpu_reference result %lf\n", elapsed, maxflow);
   printf("CPU Elapsed: %lf ms, maxflow result %lf\n", elapsed, maxflow);
+  
   //
   // Extracting results on CPU
   //
-
-  std::vector<std::vector<ValueT>> boost_flow;
-  boost_flow.resize(graph.nodes);
-  for (auto x = 0; x < graph.nodes; ++x) boost_flow[x].resize(graph.nodes, 0.0);
+  std::map<std::pair<VertexT, VertexT>, VertexT> edge_id;
+  for (VertexT x = 0; x < graph.nodes; ++x) {
+	  auto e_start = graph.CsrT::GetNeighborListOffset(x);
+	  auto num_neighbors = graph.CsrT::GetNeighborListLength(x);
+	  auto e_end = e_start + num_neighbors;
+	  for (VertexT e = e_start; e < e_end; ++e) {
+		  VertexT y = graph.CsrT::GetEdgeDest(e);
+		  edge_id[std::make_pair(x, y)] = e;
+	  }
+  }
   typename graph_traits<Graph>::vertex_iterator u_it, u_end;
   typename graph_traits<Graph>::out_edge_iterator e_it, e_end;
   for (tie(u_it, u_end) = vertices(boost_graph); u_it != u_end; ++u_it) {
-    for (tie(e_it, e_end) = out_edges(*u_it, boost_graph); e_it != e_end;
-         ++e_it) {
+    for (tie(e_it, e_end) = out_edges(*u_it, boost_graph); e_it != e_end; ++e_it) {
       if (capacity[*e_it] > 0) {
         ValueT e_f = capacity[*e_it] - residual_capacity[*e_it];
         VertexT t = target(*e_it, boost_graph);
-        // debug_aml("flow on edge %d - %d = %lf\n", *u_it, t, e_f);
-        boost_flow[*u_it][t] = e_f;
+	flow[edge_id[std::make_pair(*u_it, t)]] = e_f;
       }
-    }
-  }
-  for (auto x = 0; x < graph.nodes; ++x) {
-    auto e_start = graph.CsrT::GetNeighborListOffset(x);
-    auto num_neighbors = graph.CsrT::GetNeighborListLength(x);
-    auto e_end = e_start + num_neighbors;
-    for (auto e = e_start; e < e_end; ++e) {
-      VertexT y = graph.CsrT::GetEdgeDest(e);
-      flow[e] = boost_flow[x][y];
     }
   }
 

--- a/gunrock/app/mf/mf_test.cuh
+++ b/gunrock/app/mf/mf_test.cuh
@@ -25,6 +25,7 @@
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/edmonds_karp_max_flow.hpp>
+#include <boost/graph/boykov_kolmogorov_max_flow.hpp>
 #include <boost/graph/read_dimacs.hpp>
 #include <iostream>
 #include <string>
@@ -281,9 +282,12 @@ double CPU_Reference(util::Parameters& parameters, GraphT& graph, VertexT src,
   util::CpuTimer cpu_timer;
   cpu_timer.Start();
   maxflow = edmonds_karp_max_flow(boost_graph, source, sink);
+  //maxflow = boykov_kolmogorov_max_flow(boost_graph, source, sink);
   cpu_timer.Stop();
   elapsed = cpu_timer.ElapsedMillis();
 
+  fprintf(stderr, "CPU Elapsed: %lf ms, cpu_reference result %lf\n", elapsed, maxflow);
+  printf("CPU Elapsed: %lf ms, maxflow result %lf\n", elapsed, maxflow);
   //
   // Extracting results on CPU
   //
@@ -437,6 +441,7 @@ int Validate_Results(util::Parameters& parameters, GraphT& graph,
     }
   }
   util::PrintMsg("Max Flow GPU = " + std::to_string(flow_incoming_sink));
+  fprintf(stderr, "lockfree maxflow %lf\n", flow_incoming_sink);
 
   // Verify min cut h_flow
   ValueT mincut_flow = (ValueT)0;
@@ -493,7 +498,7 @@ int Validate_Results(util::Parameters& parameters, GraphT& graph,
       util::PrintMsg(std::to_string(num_errors) + " errors occurred.", !quiet);
     } else {
       util::PrintMsg("PASS", !quiet);
-      fprintf(stderr, "PASS\n");
+      //fprintf(stderr, "PASS\n");
     }
   } else {
     util::PrintMsg("Flow Validity:\n", !quiet, false);
@@ -536,7 +541,7 @@ int Validate_Results(util::Parameters& parameters, GraphT& graph,
       util::PrintMsg(std::to_string(num_errors) + " errors occurred.", !quiet);
     } else {
       util::PrintMsg("PASS", !quiet);
-      fprintf(stderr, "PASS\n");
+      //fprintf(stderr, "PASS\n");
     }
   }
 

--- a/tests/mf/test_mf.cu
+++ b/tests/mf/test_mf.cu
@@ -111,15 +111,20 @@ struct main_struct {
     debug_aml("number of edges %d", u_graph.edges);
     debug_aml("number of nodes %d", u_graph.nodes);
 
+    std::map<std::pair<VertexT, VertexT>, SizeT> d_edge_id;
+    std::map<std::pair<VertexT, VertexT>, SizeT> u_edge_id;
+    app::mf::GetEdgesIds(d_graph, d_edge_id);
+    app::mf::GetEdgesIds(u_graph, u_edge_id);
+
     ValueT *flow_edge = NULL;
 
     util::Array1D<SizeT, VertexT> reverse;
     GUARD_CU(reverse.Allocate(u_graph.edges, util::HOST));
-    app::mf::InitReverse(u_graph, reverse.GetPointer(util::HOST));
+    app::mf::InitReverse(u_graph, u_edge_id, reverse.GetPointer(util::HOST));
 
     if (not undirected) {
       // Correct capacity values on reverse edges
-      app::mf::CorrectCapacity(u_graph, d_graph);
+      app::mf::CorrectCapacity(u_graph, d_graph, d_edge_id);
     }
 
     //
@@ -131,7 +136,7 @@ struct main_struct {
       util::PrintMsg("______CPU reference algorithm______", true);
       flow_edge = (ValueT *)malloc(sizeof(ValueT) * u_graph.edges);
       double elapsed =
-          app::mf::CPU_Reference(parameters, u_graph, source, sink, max_flow,
+          app::mf::CPU_Reference(parameters, u_graph, u_edge_id, source, sink, max_flow,
                                  reverse.GetPointer(util::HOST), flow_edge);
       util::PrintMsg("-----------------------------------\nElapsed: " +
                          std::to_string(elapsed) +


### PR DESCRIPTION
- for Boost cpu reference algorithm I changed for Boykov Kolmogorov instead of Edmonds Karp (so now we have our own "parametric maxflow" as the Boost CPU Reference algorithm)
- Refactoring: I added std::map for mapping pair of vertices to the edge because 2dim array, which I was using instead before, saturated memory and was killing by system (for the biggest test it took around 257GB). It also speeds up a little bit preparing data so waiting for testing is shorter.