### PR TITLE
Reducing memory usage 

### DIFF
--- a/gunrock/app/knn/knn_app.cu
+++ b/gunrock/app/knn/knn_app.cu
@@ -82,7 +82,8 @@ cudaError_t UseParameters(util::Parameters &parameters) {
  */
 template <typename GraphT>
 cudaError_t RunTests(util::Parameters &parameters, GraphT &graph,
-                     typename GraphT::SizeT k, typename GraphT::SizeT eps,
+                     typename GraphT::SizeT k, 
+                     typename GraphT::SizeT eps,
                      typename GraphT::SizeT min_pts,
                      typename GraphT::SizeT *h_cluster,
                      typename GraphT::SizeT *ref_cluster,

--- a/gunrock/util/device_intrinsics.cuh
+++ b/gunrock/util/device_intrinsics.cuh
@@ -177,6 +177,18 @@ __device__ static unsigned long atomicAdd(unsigned long *addr, unsigned long val
 }*/
 #endif
 
+__device__ static uint64_t atomicMin(uint64_t* addr, uint64_t val)
+{
+    unsigned long long int pre_value = (unsigned long long int)val;
+    unsigned long long int old = (unsigned long long int)val;
+    unsigned long long int expected;
+    do {
+        expected = old;
+        old = atomicCAS((unsigned long long int*)addr, val, (unsigned long long int)val);
+    } while (expected != old);
+    return old;
+}
+
 __device__ static float atomicMin(float* addr, float val)
 {
     int* addr_as_int = (int*)addr;

--- a/tests/knn/Makefile
+++ b/tests/knn/Makefile
@@ -17,7 +17,7 @@ test: $(EXEC)
 
 $(EXEC) : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
-	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O0
+	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
 
 a : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin

--- a/tests/knn/test_knn.cu
+++ b/tests/knn/test_knn.cu
@@ -100,7 +100,8 @@ struct main_struct {
       util::PrintMsg("__________________________", !quiet);
       util::PrintMsg("______ CPU Reference _____", !quiet);
 
-      float elapsed = app::knn::CPU_Reference(graph.csr(), k, eps, min_pts, point_x, point_y, ref_cluster, quiet);
+      float elapsed = app::knn::CPU_Reference(graph.csr(), k, eps, min_pts, 
+              point_x, point_y, ref_cluster, quiet);
 
       util::PrintMsg(
           "--------------------------\n Elapsed: " + std::to_string(elapsed),


### PR DESCRIPTION
Reducing memory usage from O(N^2) to 4 arrays of size N, 4 arrays of size E and one array of size k*N.
Time complexity of density_op changed to O(N^2) in the worst case. 
Refactoring done. 
Adding implementation of atomicMin operation for uint64