### PR TITLE
HITS Optimization

### DIFF
--- a/gunrock/app/hits/hits_enactor.cuh
+++ b/gunrock/app/hits/hits_enactor.cuh
@@ -102,7 +102,10 @@ struct hitsIterationLoop : public IterationLoopBase
 
         // Number of times to iterate the HITS algorithm
         auto max_iter = data_slice.max_iter;
-        auto normalize_every = data_slice.normalize_every;
+
+        // Normalize the HITS scores every N iterations.
+        // Provides speedup at the risk of data overflow
+        auto normalize_n = data_slice.normalize_n;
 
         // Reset next ranks to zero
         auto reset_zero_op = 
@@ -146,7 +149,9 @@ struct hitsIterationLoop : public IterationLoopBase
             "cudaStreamSynchronize Failed");
 
         // After updating the scores, normalize the hub and array scores
-        if (normalize_every || iteration == (max_iter - 1) )
+        // either after every N iterations (user-specified, default=1),
+        // or at the last iteration
+        if ( ((iteration+1) % normalize_n == 0) || iteration == (max_iter - 1) )
         {
             // 1) Square each element
             auto square_op =

--- a/gunrock/app/hits/hits_problem.cuh
+++ b/gunrock/app/hits/hits_problem.cuh
@@ -39,11 +39,11 @@ cudaError_t UseParameters_problem(
         "Number of HITS iterations.",
         __FILE__, __LINE__));
 
-    GUARD_CU(parameters.Use<bool>(
-        "normalize-every",
-        util::REQUIRED_ARGUMENT | util::SINGLE_VALUE | util::OPTIONAL_PARAMETER,
-        true,
-        "Normalize the hub and authority scores after every iteration.",
+    GUARD_CU(parameters.Use<int64_t>(
+        "normalize-n",
+        util::REQUIRED_ARGUMENT | util::MULTI_VALUE | util::OPTIONAL_PARAMETER,
+        1,
+        "Normalize HITS scores every N iterations.",
         __FILE__, __LINE__));
 
     GUARD_CU(parameters.Use<double>(
@@ -94,13 +94,13 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
         util::Array1D<SizeT, ValueT> hrank_mag;
         util::Array1D<SizeT, ValueT> arank_mag;
 	    SizeT max_iter;                             // Maximum number of HITS iterations to perform
-	    bool normalize_every;                        // Whether to normalize scores every iteration	
+	    SizeT normalize_n;                        // Normalize every N iterations
         /*
          * @brief Default constructor
          */
         DataSlice() : BaseDataSlice(),
             max_iter(0),
-            normalize_every(false)
+            normalize_n(0)
         {
             // Name of the problem specific arrays:
             hrank_curr.SetName("hrank_curr");
@@ -340,8 +340,8 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
             data_slice.max_iter
                 = this -> parameters.template Get<SizeT >("max-iter");
 
-            data_slice.normalize_every
-                = this -> parameters.template Get<bool >("normalize-every");
+            data_slice.normalize_n
+                = this -> parameters.template Get<SizeT >("normalize-n");
 
             GUARD_CU(data_slice.Init(
                 this -> sub_graphs[gpu],


### PR DESCRIPTION
Performance improvements can be gained by normalizing HITS hub and authority scores every N iterations. By default N = 1 (every iteration), so that the algorithm will function correctly on any graph input. Increasing N presents a risk that the hub and authority scores will overflow (displayed as "nan"), even when using 64-bit values, therefore the user should expect to go through some trial and error for a given graph when attempting to increase N.