### PR TITLE
HITS fix

### DIFF
--- a/gunrock/app/hits/hits_problem.cuh
+++ b/gunrock/app/hits/hits_problem.cuh
@@ -218,11 +218,11 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
 
             GUARD_CU(hrank_mag.ForEach([]__host__ __device__ (ValueT &x){
                 x = (ValueT)0.0;
-            }, nodes, target, this -> stream));
+            }, 1, target, this -> stream));
 
              GUARD_CU(arank_mag.ForEach([]__host__ __device__ (ValueT &x){
                 x = (ValueT)0.0;
-            }, nodes, target, this -> stream));
+            }, 1, target, this -> stream));
 
             return retval;
         }


### PR DESCRIPTION
Magnitude vectors are only allocated with space for 1 element but the initialization function was set to initialize a vector with length equal to the number of nodes in the graph.