### PR TITLE
Correctly propogate the device number to sysinfo.h

### DIFF
--- a/gunrock/util/sysinfo.h
+++ b/gunrock/util/sysinfo.h
@@ -81,7 +81,8 @@ public:
         {
             return info;        /* empty */
         }
-        int dev = 0;            /* currently assumes GPU 0 */
+        int dev = 0;
+        cudaGetDevice(&dev);
         cudaGetDeviceProperties(&devProps, dev);
         info["name"] = devProps.name;
         info["total_global_mem"] = int64_t(devProps.totalGlobalMem);


### PR DESCRIPTION
Fix for #348 

Correctly propagates the device number to sysinfo.h so it is written to the json output file.