### PR TITLE
add docker for ubuntu1604-cuda10.1

### DIFF
--- a/docker/ubuntu16.04-cuda10.1/README.md
+++ b/docker/ubuntu16.04-cuda10.1/README.md
@@ -1,0 +1,10 @@
+#### Instructions
+
+```
+user@home$ docker build . -t gunrock                       # Build container
+user@home$ nvidia-docker run -it gunrock /bin/bash         # Start bash session in container
+
+root@docker$ cd gunrock/build
+root@docker$ make test                                     # Run tests
+root@docker$ ./bin/cc market ../dataset/small/data_sm.mtx  # Run app
+```

--- a/docker/ubuntu16.04-cuda10.1/dockerfile
+++ b/docker/ubuntu16.04-cuda10.1/dockerfile
@@ -1,0 +1,15 @@
+FROM nvidia/cuda:10.1-devel-ubuntu16.04
+
+########################
+# Install Dependencies #
+########################
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake git libboost-all-dev && rm -rf /var/lib/apt/lists/*
+
+#################
+# Build Gunrock #
+#################
+
+RUN git clone --recursive https://github.com/gunrock/gunrock.git && \
+    cd gunrock && mkdir build && cd build && cmake .. && make -j$(nproc)

--- a/victor/build_debug.sh
+++ b/victor/build_debug.sh
@@ -1,0 +1,5 @@
+cd ..
+rm -fr build_debug
+mkdir build_debug
+cd build_debug
+cmake -DCMAKE_BUILD_TYPE=Debug -DGUNROCK_BUILD_TESTS=ON -DGUNROCK_GOOGLE_TESTS=ON .. && make -j$(nproc)

--- a/victor/build_gtest.sh
+++ b/victor/build_gtest.sh
@@ -1,0 +1,7 @@
+cd ..
+rm -fr build_gtest
+mkdir build_gtest
+cd build_gtest
+#CC=clang-6.0 CXX=clang++-6.0 cmake -DGUNROCK_BUILD_TESTS=ON -DGUNROCK_GOOGLE_TESTS=ON .. && make -j$(nproc)
+cmake .. && make -j$(nproc) 2>&1 |tee build.log
+ctest -V  2>&1 |tee ctest.log

--- a/victor/build_profile.sh
+++ b/victor/build_profile.sh
@@ -1,0 +1,6 @@
+cd ..
+rm -fr build_profile
+mkdir build_profile
+cd build_profile
+#CC=clang-6.0 CXX=clang++-6.0 cmake -DGUNROCK_BUILD_TESTS=ON -DGUNROCK_GOOGLE_TESTS=ON .. && make -j$(nproc)
+CFLAG="-pg" CXXFLAG="-pg" cmake -DGUNROCK_BUILD_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMAND=YES .. && make -j$(nproc)

--- a/victor/get_sp_cmd.py
+++ b/victor/get_sp_cmd.py
@@ -1,0 +1,33 @@
+cmd_list = [
+
+"""/gunrock_src/build_gtest/bin/bc "market" "/gunrock_src/dataset/small/bips98_606.mtx" "--undirected" "--src=0" """,
+"""/gunrock_src/build_gtest/bin/bfs "market" "/gunrock_src/dataset/small/bips98_606.mtx" "--undirected" "--src=0" """,
+"""/gunrock_src/build_gtest/bin/color "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--undirected" """,
+"""/gunrock_src/build_gtest/bin/geo "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--labels-file=/gunrock_src/examples/geo/_data/samples/sample.labels" """,
+"""/gunrock_src/build_gtest/bin/hits "market" "/gunrock_src/dataset/small/bips98_606.mtx" """,
+"""/gunrock_src/build_gtest/bin/knn "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--k=5" """,
+"""/gunrock_src/build_gtest/bin/louvain "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--omp-threads=32" "--advance-mode=ALL_EDGES" "--unify-segments=true" """,
+"""/gunrock_src/build_gtest/bin/pr "market" "/gunrock_src/dataset/small/bips98_606.mtx" "--normalized" "--compensate" "--undirected" """,
+"""/gunrock_src/build_gtest/bin/pr_nibble "market" "/gunrock_src/dataset/small/chesapeake.mtx" """,
+"""/gunrock_src/build_gtest/bin/proj "market" "/gunrock_src/dataset/small/chesapeake.mtx" """,
+"""/gunrock_src/build_gtest/bin/rw "market" "/gunrock_src/dataset/small/chesapeake.mtx" """,
+"""/gunrock_src/build_gtest/bin/sage "market" "/gunrock_src/dataset/small/chesapeake.mtx" """,
+"""/gunrock_src/build_gtest/bin/sm "market" "/gunrock_src/dataset/small/tree.mtx" "--pattern-graph-type=market" "--pattern-graph-file=/gunrock_src/dataset/small/query_sm.mtx" "--undirected=1" "--pattern-undirected=1" "--num-runs=1" "--quiet=false" """,
+"""/gunrock_src/build_gtest/bin/ss "market" "/gunrock_src/dataset/small/chesapeake.mtx" """,
+"""/gunrock_src/build_gtest/bin/sssp "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--undirected" "--src=0" """,
+"""/gunrock_src/build_gtest/bin/tc "market" "/gunrock_src/dataset/small/chesapeake.mtx" "--sort-csr" """,
+"""/gunrock_src/build_gtest/bin/shared_lib_pr """,
+]
+
+print("cmds =   [")
+for cmd in cmd_list:
+    name = cmd.split(" ")[0].split('/')[-1]
+    print("    {")
+    print("""  name: {},""".format(name)) 
+    print("""  cmd: {},""".format(cmd)) 
+    print("""  env: { 'CUDA_VISIBLE_DEVICES':'0', },""") 
+    print("""  ret: 0 ,""")
+    print("""  wrk: '', """) 
+
+    print("    },")
+print("]")


### PR DESCRIPTION
build success on nvidia/cuda:10.1-devel-ubuntu16.04 :
```
....
Scanning dependencies of target vn
[ 95%] Building C object examples/vn/CMakeFiles/vn.dir/__/__/gunrock/util/gitsha1.c.o
[ 96%] Building CXX object examples/vn/CMakeFiles/vn.dir/__/__/externals/moderngpu/src/mgpuutil.cpp.o
[ 97%] Linking CXX executable ../../bin/vn
[ 97%] Built target vn
[ 98%] Building NVCC intermediate link file examples/sssp/CMakeFiles/sssp.dir/sssp_intermediate_link.o
Scanning dependencies of target sssp
[ 98%] Building C object examples/sssp/CMakeFiles/sssp.dir/__/__/gunrock/util/gitsha1.c.o
[ 99%] Building CXX object examples/sssp/CMakeFiles/sssp.dir/__/__/externals/moderngpu/src/mgpuutil.cpp.o
[100%] Linking CXX executable ../../bin/sssp
[100%] Built target sssp
Removing intermediate container 9654aa969af1
 ---> 19978ca18540
Successfully built 19978ca18540
Successfully tagged gunrock:latest
```