### PR TITLE
Compile for detected compute capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,17 +256,17 @@ option(GUNROCK_GENCODE_SM52
 if (CUDA_VERSION VERSION_EQUAL "8.0" OR CUDA_VERSION VERSION_GREATER "8.0")
   option(GUNROCK_GENCODE_SM60
     "ON to generate code for Compute Capability 6.0 devices (e.g. Tesla P100)"
-    ON)
+    OFF)
   option(GUNROCK_GENCODE_SM61
     "ON to generate code for Compute Capability 6.1 devices (e.g. GeForce GTX 1080)"
-    ON)
+    OFF)
 endif ()
 
 #Volta Architecture: CUDA 9
 if (CUDA_VERSION VERSION_EQUAL "9.0" OR CUDA_VERSION VERSION_GREATER "9.0")
   option(GUNROCK_GENCODE_SM70
     "ON to generate code for Compute Capability 7.0 devices (e.g. Volta V100)"
-    ON)
+    OFF)
   option(GUNROCK_GENCODE_SM72
     "ON to generate code for Compute Capability 7.2 devices (e.g. Jetson AGX Xavier)"
     OFF)
@@ -276,12 +276,21 @@ endif ()
 if (CUDA_VERSION VERSION_EQUAL "10.0" OR CUDA_VERSION VERSION_GREATER "10.0")
   option(GUNROCK_GENCODE_SM75
     "ON to generate code for Compute Capability 7.5 devices (e.g. GTX 1160 or RTX 2080)"
-    ON)
+    OFF)
 endif ()
+
+option (CUDA_AUTODETECT_GENCODE
+  "On to enable autodetection of appropriate gencode=X options for each detected device"
+  ON)
 
 option(CUDA_VERBOSE_PTXAS
   "On to enable verbose output from the PTXAS assembler."
   OFF)
+
+if (CUDA_AUTODETECT_GENCODE)
+  include(${CMAKE_SOURCE_DIR}/cmake/AutoDetectCudaArch.cmake)
+  set(GENCODE ${GENCODE} ${CUDA_ARCHS})
+endif ()
 
 if (GUNROCK_GENCODE_SM10)
   set(GENCODE ${GENCODE} ${GENCODE_SM10})
@@ -334,6 +343,11 @@ endif(GUNROCK_GENCODE_SM72)
 if (GUNROCK_GENCODE_SM75)
   set(GENCODE ${GENCODE} ${GENCODE_SM75})
 endif(GUNROCK_GENCODE_SM75)
+
+message(STATUS "Listing chosen GENCODE commands")
+foreach(code IN LISTS GENCODE)
+    message(STATUS "${code}")
+endforeach() 
 
 if (CUDA_VERBOSE_PTXAS)
   set(VERBOSE_PTXAS --ptxas-options=-v)

--- a/cmake/AutoDetectCudaArch.cmake
+++ b/cmake/AutoDetectCudaArch.cmake
@@ -1,0 +1,67 @@
+if(NOT DEFINED CUDA_ARCHS)
+	############################### Autodetect CUDA Arch #####################################################
+	#Auto-detect cuda arch. Inspired by https://wagonhelm.github.io/articles/2018-03/detecting-cuda-capability-with-cmake
+	# This will define and populates CUDA_ARCHS and put it in the cache 
+	#Windows users (specially on VS2017 and VS2015) might need to run this 
+	#>> "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+	# and change Enterprise to the right edition. More about this here https://stackoverflow.com/a/47746461/1608232
+	if(CUDA_FOUND)
+		set(cuda_arch_autodetect_file ${CMAKE_BINARY_DIR}/autodetect_cuda_archs.cu)		
+		
+		file(WRITE ${cuda_arch_autodetect_file} ""
+		"#include <stdio.h>\n"
+		"int main() {\n"
+		"	int count = 0; \n"
+		"	if (cudaSuccess != cudaGetDeviceCount(&count)) { return -1; }\n"
+		"	if (count == 0) { return -1; }\n"
+		"	for (int device = 0; device < count; ++device) {\n"
+		"		cudaDeviceProp prop; \n"
+		"		bool is_unique = true; \n"
+		"		if (cudaSuccess == cudaGetDeviceProperties(&prop, device)) {\n"
+		"			for (int device_1 = device - 1; device_1 >= 0; --device_1) {\n"
+		"				cudaDeviceProp prop_1; \n"
+		"				if (cudaSuccess == cudaGetDeviceProperties(&prop_1, device_1)) {\n"
+		"					if (prop.major == prop_1.major && prop.minor == prop_1.minor) {\n"
+		"						is_unique = false; \n"
+		"						break; \n"
+		"					}\n"
+		"				}\n"
+		"				else { return -1; }\n"
+		"			}\n"
+		"			if (is_unique) {\n"
+		"				fprintf(stderr, \"-gencode=arch=compute_%d%d,code=sm_%d%d;\", prop.major, prop.minor, prop.major, prop.minor);\n"
+		"				fprintf(stderr, \"-gencode=arch=compute_%d%d,code=compute_%d%d;\", prop.major, prop.minor, prop.major, prop.minor);\n"
+		"			}\n"
+		"		}\n"
+		"		else { return -1; }\n"
+		"	}\n"
+		"	return 0; \n"
+		"}\n")	
+		
+		execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${cuda_arch_autodetect_file}"
+						#WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/CMakeFiles/"	
+						RESULT_VARIABLE CUDA_RETURN_CODE	
+						OUTPUT_VARIABLE dummy
+						ERROR_VARIABLE fprintf_output					
+						OUTPUT_STRIP_TRAILING_WHITESPACE)							
+		
+		if(CUDA_RETURN_CODE EQUAL 0)			
+			set(CUDA_ARCHS ${fprintf_output} CACHE STRING "CUDA Arch")
+		else()
+			message(STATUS "GPU architectures auto-detect failed. Will build for all possible architectures.")      
+			set(CUDA_ARCHS -gencode=arch=compute_30,code=sm_30
+			               -gencode=arch=compute_35,code=sm_35
+			               -gencode=arch=compute_37,code=sm_37
+			               -gencode=arch=compute_50,code=sm_50
+			               -gencode=arch=compute_52,code=sm_52
+			               -gencode=arch=compute_60,code=sm_60
+			               -gencode=arch=compute_61,code=sm_61
+			               -gencode=arch=compute_70,code=sm_70
+			               -gencode=arch=compute_72,code=sm_72
+			               -gencode=arch=compute_75,code=sm_75
+						   CACHE STRING "CUDA Arch")			
+		endif()  
+	endif()
+	message(STATUS "CUDA Autodetected, setting CUDA_ARCHS=" ${CUDA_ARCHS})	
+endif()
+###################################################################################


### PR DESCRIPTION
Gunrock currently compiles for practically all possible compute
capabilites, which requires extremely long build times. It also causes
several warnings to be generated when these various combos of options
go the compiler. This change greatly reduces the amount of code we
normally compile in development, and reduces the complexity of build
configurations.

The file AutoDetectCudaArch.cmake was written by Ahmed Mahmoud.