### PR TITLE
Remove hard-coded and ambiguous CUDA_ARCH

### DIFF
--- a/gunrock/app/cc/cc_enactor.cuh
+++ b/gunrock/app/cc/cc_enactor.cuh
@@ -1185,7 +1185,7 @@ class CCEnactor
 
   typedef gunrock::oprtr::advance::KernelPolicy<
       Problem,   // Problem data type
-      300,       // CUDA_ARCH
+      GR_CUDA_ARCH,       // CUDA_ARCH
       8,         // MIN_CTA_OCCUPANCY,
       8,         // LOG_THREADS,
       8,         // LOG_BLOCKS,

--- a/gunrock/oprtr/AE_advance/kernel.cuh
+++ b/gunrock/oprtr/AE_advance/kernel.cuh
@@ -36,10 +36,10 @@ namespace AE {
  */
 template <OprtrFlag FLAG, typename GraphT, typename InKeyT, typename OutKeyT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {

--- a/gunrock/oprtr/AE_advance/kernel_policy.cuh
+++ b/gunrock/oprtr/AE_advance/kernel_policy.cuh
@@ -51,7 +51,6 @@ struct KernelPolicy {
   typedef _ValueT ValueT;
 
   enum {
-    // CUDA_ARCH                       = _CUDA_ARCH,
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     LOG_BLOCKS = _LOG_BLOCKS,
@@ -73,10 +72,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MAX_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
     VALID = (CTA_OCCUPANCY > 0),
   };

--- a/gunrock/oprtr/BP_filter/kernel.cuh
+++ b/gunrock/oprtr/BP_filter/kernel.cuh
@@ -29,10 +29,10 @@ namespace BP {
  */
 template <OprtrFlag FLAG, typename InKeyT, typename OutKeyT, typename SizeT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {

--- a/gunrock/oprtr/BP_filter/kernel_policy.cuh
+++ b/gunrock/oprtr/BP_filter/kernel_policy.cuh
@@ -38,7 +38,6 @@ struct KernelPolicy {
   // typedef _ValueT   ValueT;
 
   enum {
-    // CUDA_ARCH                       = _CUDA_ARCH,
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     LOG_BLOCKS = _LOG_BLOCKS,
@@ -58,10 +57,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MAX_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
     VALID = (CTA_OCCUPANCY > 0),
   };

--- a/gunrock/oprtr/CULL_filter/kernel.cuh
+++ b/gunrock/oprtr/CULL_filter/kernel.cuh
@@ -102,10 +102,10 @@ struct SweepPass {
 template <OprtrFlag FLAG, typename InKeyT, typename OutKeyT, typename SizeT,
           typename ValueT, typename LabelT, typename FilterOpT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {
@@ -115,11 +115,6 @@ template <OprtrFlag FLAG, typename InKeyT, typename OutKeyT, typename SizeT,
           typename ValueT, typename LabelT, typename FilterOpT>
 struct Dispatch<FLAG, InKeyT, OutKeyT, SizeT, ValueT, LabelT, FilterOpT, true> {
   typedef KernelPolicy<FLAG, InKeyT, OutKeyT, SizeT, ValueT, LabelT, FilterOpT,
-                       //#ifdef __CUDA_ARCH__
-                       //    __CUDA_ARCH__,                      // CUDA_ARCH
-                       //#else
-                       //    0,
-                       //#endif
                        sizeof(InKeyT) == 4 ? 8 : 4,  // MAX_CTA_OCCUPANCY
                        8,                            // LOG_THREADS
                        1,                            // LOG_LOAD_VEC_SIZE

--- a/gunrock/oprtr/LB_CULL_advance/kernel.cuh
+++ b/gunrock/oprtr/LB_CULL_advance/kernel.cuh
@@ -39,10 +39,10 @@ namespace LB_CULL {
 template <OprtrFlag FLAG, typename GraphT, typename InKeyT, typename OutKeyT,
           typename ValueT, typename LabelT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {

--- a/gunrock/oprtr/LB_CULL_advance/kernel_policy.cuh
+++ b/gunrock/oprtr/LB_CULL_advance/kernel_policy.cuh
@@ -33,8 +33,6 @@ namespace LB_CULL {
  * architectures and problem types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
- * for.
  * @tparam _INSTRUMENT                  Whether or not we want instrumentation
  * logic generated
  * @tparam _MIN_CTA_OCCUPANCY           Lower bound on number of CTAs to have
@@ -48,7 +46,6 @@ template <
     typename _VertexT,  // Data types
     typename _InKeyT, typename _OutKeyT, typename _SizeT, typename _ValueT,
     typename _LabelT,
-    // int _CUDA_ARCH,         // Machine parameters
     // int _MIN_CTA_OCCUPANCY, // Tunable parameters
     int _MAX_CTA_OCCUPANCY, int _LOG_THREADS, int _LOG_BLOCKS,
     int _LIGHT_EDGE_THRESHOLD>
@@ -68,7 +65,6 @@ class KernelPolicy {
 
   enum {
     FLAG = _FLAG,
-    // CUDA_ARCH                       = _CUDA_ARCH,
     // INSTRUMENT                      = _INSTRUMENT,
 
     LOG_THREADS = _LOG_THREADS,
@@ -76,7 +72,7 @@ class KernelPolicy {
     LOG_BLOCKS = _LOG_BLOCKS,
     BLOCKS = 1 << LOG_BLOCKS,
     LIGHT_EDGE_THRESHOLD = _LIGHT_EDGE_THRESHOLD,
-    WARP_SIZE = GR_WARP_THREADS(CUDA_ARCH),
+    WARP_SIZE = GR_WARP_THREADS(GR_CUDA_ARCH),
     LOG_WARP_SIZE = 5,
     WARP_SIZE_MASK = WARP_SIZE - 1,
     WARPS = THREADS / WARP_SIZE,
@@ -195,10 +191,10 @@ class KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MAX_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
 
     VALID = (CTA_OCCUPANCY > 0),

--- a/gunrock/oprtr/LB_advance/kernel.cuh
+++ b/gunrock/oprtr/LB_advance/kernel.cuh
@@ -41,10 +41,10 @@ namespace LB {
  */
 template <OprtrFlag FLAG, typename GraphT, typename InKeyT, typename OutKeyT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {

--- a/gunrock/oprtr/LB_advance/kernel_policy.cuh
+++ b/gunrock/oprtr/LB_advance/kernel_policy.cuh
@@ -49,10 +49,6 @@ struct KernelPolicy {
   typedef _ValueT ValueT;
 
   enum {
-
-    // CUDA_ARCH                       = _CUDA_ARCH,
-    // INSTRUMENT                      = _INSTRUMENT,
-
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     LOG_BLOCKS = _LOG_BLOCKS,
@@ -90,10 +86,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MAX_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
 
     VALID = (CTA_OCCUPANCY > 0),

--- a/gunrock/oprtr/TWC_advance/kernel.cuh
+++ b/gunrock/oprtr/TWC_advance/kernel.cuh
@@ -40,10 +40,10 @@ namespace TWC {
  */
 template <OprtrFlag FLAG, typename GraphT, typename InKeyT, typename OutKeyT,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
+              false
 #endif
           >
 struct Dispatch {

--- a/gunrock/oprtr/TWC_advance/kernel_policy.cuh
+++ b/gunrock/oprtr/TWC_advance/kernel_policy.cuh
@@ -34,8 +34,6 @@ namespace TWC {
  * architectures and problem types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
- * for.
  * @tparam _INSTRUMENT                  Whether or not we want instrumentation
  * logic generated
  * @tparam _MIN_CTA_OCCUPANCY           Lower bound on number of CTAs to have
@@ -84,7 +82,6 @@ struct KernelPolicy {
 
   enum {
     FLAG = _FLAG,
-    // CUDA_ARCH                       = _CUDA_ARCH,
     // INSTRUMENT                      = _INSTRUMENT,
 
     LOG_THREADS = _LOG_THREADS,
@@ -117,7 +114,7 @@ struct KernelPolicy {
 
   // Prefix sum raking grid for coarse-grained expansion allocations
   typedef gunrock::util::RakingGrid<
-      CUDA_ARCH,
+      GR_CUDA_ARCH,
       SizeT,               // Partial type
       LOG_THREADS,         // Depositing threads (the CTA size)
       LOG_LOADS_PER_TILE,  // Lanes (the number of loads)
@@ -127,7 +124,7 @@ struct KernelPolicy {
 
   // Prefix sum raking grid for fine-grained expansion allocations
   typedef gunrock::util::RakingGrid<
-      CUDA_ARCH,
+      GR_CUDA_ARCH,
       SizeT,               // Partial type
       LOG_THREADS,         // Depositing threads (the CTA size)
       LOG_LOADS_PER_TILE,  // Lanes (the number of loads)
@@ -200,7 +197,7 @@ struct KernelPolicy {
       // Amount of storage we can use for hashing scratch space under target
       // occupancy
       MAX_SCRATCH_BYTES_PER_CTA =
-          (GR_SMEM_BYTES(CUDA_ARCH) / _MIN_CTA_OCCUPANCY) - sizeof(State) -
+          (GR_SMEM_BYTES(GR_CUDA_ARCH) / _MIN_CTA_OCCUPANCY) - sizeof(State) -
           128,  // Fudge-factor to guarantee occupancy
 
       SCRATCH_ELEMENT_SIZE =
@@ -231,10 +228,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MIN_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
 
     VALID = (CTA_OCCUPANCY > 0),

--- a/gunrock/oprtr/advance/kernel_policy.cuh
+++ b/gunrock/oprtr/advance/kernel_policy.cuh
@@ -38,8 +38,6 @@ namespace advance {
  * architectures and problem types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
- * for.
  * @tparam _INSTRUMENT                  Whether or not we want instrumentation
  * logic generated
  * @tparam _MIN_CTA_OCCUPANCY           Lower bound on number of CTAs to have
@@ -69,10 +67,6 @@ namespace advance {
  * advance operator we use: TWC_FORWARD, TWC_BACKWARD, LB)
  */
 template <typename _Problem,
-          // Machine parameters
-          int _CUDA_ARCH,
-          // Behavioral control parameters
-          // bool _INSTRUMENT,
           // Tunable parameters
           int _MAX_CTA_OCCUPANCY, int _LOG_THREADS, int _LOG_BLOCKS,
           int _LIGHT_EDGE_THRESHOLD, int _LOG_LOAD_VEC_SIZE,
@@ -90,48 +84,41 @@ struct KernelPolicy {
   static const MODE ADVANCE_MODE = _ADVANCE_MODE;
 
   enum {
-    CUDA_ARCH = _CUDA_ARCH,
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
   };
 
   typedef gunrock::oprtr::edge_map_forward::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _WARP_GATHER_THRESHOLD, _CTA_GATHER_THRESHOLD,
       _LOG_SCHEDULE_GRANULARITY>
       THREAD_WARP_CTA_FORWARD;
 
   typedef gunrock::oprtr::edge_map_backward::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _WARP_GATHER_THRESHOLD, _CTA_GATHER_THRESHOLD,
       _LOG_SCHEDULE_GRANULARITY>
       THREAD_WARP_CTA_BACKWARD;
 
   typedef gunrock::oprtr::edge_map_partitioned::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_BLOCKS, _LIGHT_EDGE_THRESHOLD>
       LOAD_BALANCED;
 
   typedef gunrock::oprtr::edge_map_partitioned_backward::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_BLOCKS, _LIGHT_EDGE_THRESHOLD>
       LOAD_BALANCED_BACKWARD;
 
   typedef gunrock::oprtr::edge_map_partitioned_cull::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_BLOCKS, _LIGHT_EDGE_THRESHOLD>
       LOAD_BALANCED_CULL;
 
   typedef gunrock::oprtr::all_edges_advance::KernelPolicy<
-      _Problem, _CUDA_ARCH,
-      //_INSTRUMENT,
+      _Problem,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_BLOCKS>
       EDGES;
 

--- a/gunrock/oprtr/compacted_cull_filter/kernel.cuh
+++ b/gunrock/oprtr/compacted_cull_filter/kernel.cuh
@@ -24,7 +24,13 @@ namespace compacted_cull_filter {
 extern __device__ __host__ void Error_UnsupportedCUDAArchitecture();
 
 template <typename KernelPolicy, typename Problem, typename Functor,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID = 
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {
   typedef typename KernelPolicy::VertexId VertexId;
   typedef typename KernelPolicy::SizeT SizeT;

--- a/gunrock/oprtr/compacted_cull_filter/kernel_policy.cuh
+++ b/gunrock/oprtr/compacted_cull_filter/kernel_policy.cuh
@@ -20,7 +20,7 @@ namespace gunrock {
 namespace oprtr {
 namespace compacted_cull_filter {
 
-template <typename _Problem, int _CUDA_ARCH, int _MAX_CTA_OCCUPANCY,
+template <typename _Problem, int _MAX_CTA_OCCUPANCY,
           int _LOG_THREADS, int _LOG_GLOBAL_LOAD_SIZE, int _MODE>
 struct KernelPolicy {
   typedef _Problem Problem;
@@ -30,7 +30,6 @@ struct KernelPolicy {
 
   enum {
     MODE = _MODE,
-    CUDA_ARCH = _CUDA_ARCH,
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     MAX_BLOCKS = 1024,
@@ -79,10 +78,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(MAX_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
     VALID = (CTA_OCCUPANCY > 0),
   };

--- a/gunrock/oprtr/edge_map_backward/kernel.cuh
+++ b/gunrock/oprtr/edge_map_backward/kernel.cuh
@@ -94,7 +94,13 @@ struct Sweep {
  * @tparam VALID
  */
 template <typename KernelPolicy, typename ProblemData, typename Functor,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID =
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {
   typedef typename KernelPolicy::VertexId VertexId;
   typedef typename KernelPolicy::SizeT SizeT;

--- a/gunrock/oprtr/edge_map_partitioned_backward/kernel.cuh
+++ b/gunrock/oprtr/edge_map_partitioned_backward/kernel.cuh
@@ -41,7 +41,13 @@ namespace edge_map_partitioned_backward {
  * @tparam VALID
  */
 template <typename KernelPolicy, typename ProblemData, typename Functor,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID =
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {};
 
 template <typename KernelPolicy, typename ProblemData, typename Functor>

--- a/gunrock/oprtr/edge_map_partitioned_backward/kernel_policy.cuh
+++ b/gunrock/oprtr/edge_map_partitioned_backward/kernel_policy.cuh
@@ -54,8 +54,6 @@ namespace edge_map_partitioned_backward {
  * algorithms
  */
 template <typename _ProblemData,
-          // Machine parameters
-          int _CUDA_ARCH,
           // Behavioral control parameters
           // bool _INSTRUMENT,
           // Tunable parameters
@@ -72,10 +70,6 @@ struct KernelPolicy {
   typedef typename ProblemData::SizeT SizeT;
 
   enum {
-
-    CUDA_ARCH = _CUDA_ARCH,
-    // INSTRUMENT                      = _INSTRUMENT,
-
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     LOG_BLOCKS = _LOG_BLOCKS,
@@ -91,7 +85,7 @@ struct KernelPolicy {
       // Amount of storage we can use for hashing scratch space under target
       // occupancy
       MAX_SCRATCH_BYTES_PER_CTA =
-          (GR_SMEM_BYTES(CUDA_ARCH) / _MIN_CTA_OCCUPANCY) -
+          (GR_SMEM_BYTES(GR_CUDA_ARCH) / _MIN_CTA_OCCUPANCY) -
           128,  // Fudge-factor to guarantee occupancy
 
       SCRATCH_ELEMENT_SIZE = sizeof(SizeT) + sizeof(VertexId) * 2,
@@ -111,10 +105,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MIN_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
 
     VALID = (CTA_OCCUPANCY > 0),

--- a/gunrock/oprtr/filter/kernel_policy.cuh
+++ b/gunrock/oprtr/filter/kernel_policy.cuh
@@ -38,8 +38,6 @@ enum MODE { CULL, SIMPLIFIED, SIMPLIFIED2, COMPACTED_CULL, BY_PASS };
  * architectures and problem types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
- * for.
  * @tparam _INSTRUMENT                  Whether or not we want instrumentation
  * logic generated
  * @tparam _SATURATION_QUIT             If positive, signal that we're done with
@@ -66,7 +64,6 @@ enum MODE { CULL, SIMPLIFIED, SIMPLIFIED2, COMPACTED_CULL, BY_PASS };
 template <typename _Problem,
 
           // Machine parameters
-          int _CUDA_ARCH,
           // bool _INSTRUMENT,
           // Behavioral control parameters
           int _SATURATION_QUIT, bool _DEQUEUE_PROBLEM_SIZE,
@@ -78,36 +75,35 @@ template <typename _Problem,
           MODE _FILTER_MODE = CULL>
 struct KernelPolicy {
   static const MODE FILTER_MODE = _FILTER_MODE;
-  static const int CUDA_ARCH = _CUDA_ARCH;
 
   typedef gunrock::oprtr::cull_filter::KernelPolicy<
-      _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+      _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _END_BITMASK_CULL, _LOG_SCHEDULE_GRANULARITY,
       _FILTER_MODE>
       CULL_FILTER;
 
   typedef gunrock::oprtr::simplified_filter::KernelPolicy<
-      _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+      _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _END_BITMASK_CULL, _LOG_SCHEDULE_GRANULARITY,
       _FILTER_MODE>
       SIMPLIFIED_FILTER;
 
   typedef gunrock::oprtr::simplified2_filter::KernelPolicy<
-      _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+      _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _END_BITMASK_CULL, _LOG_SCHEDULE_GRANULARITY,
       _FILTER_MODE>
       SIMPLIFIED2_FILTER;
 
   typedef gunrock::oprtr::compacted_cull_filter::KernelPolicy<
-      _Problem, _CUDA_ARCH, _MAX_CTA_OCCUPANCY, _LOG_THREADS,
+      _Problem, _MAX_CTA_OCCUPANCY, _LOG_THREADS,
       _LOG_LOAD_VEC_SIZE + _LOG_LOADS_PER_TILE, _FILTER_MODE>
       COMPACTED_CULL_FILTER;
 
   typedef gunrock::oprtr::cull_filter::KernelPolicy<
-      _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+      _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
       _MAX_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE, _LOG_LOADS_PER_TILE,
       _LOG_RAKING_THREADS, _END_BITMASK_CULL, _LOG_SCHEDULE_GRANULARITY,
       _FILTER_MODE>

--- a/gunrock/oprtr/intersection/kernel.cuh
+++ b/gunrock/oprtr/intersection/kernel.cuh
@@ -48,11 +48,11 @@ namespace intersection {
 template <OprtrFlag FLAG, typename InKeyT, typename OutKeyT, typename SizeT,
           typename ValueT, typename VertexT, typename InterOpt,
           bool VALID =
-#ifndef __CUDA_ARCH__
-              false
+#ifdef __CUDA_ARCH__
+              true
 #else
-              (__CUDA_ARCH__ >= CUDA_ARCH)
-#endif
+              false
+#endif 
           >
 struct Dispatch {
 };

--- a/gunrock/oprtr/intersection/kernel_policy.cuh
+++ b/gunrock/oprtr/intersection/kernel_policy.cuh
@@ -45,13 +45,6 @@ parameterizing
  * types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
-for.
-<<<<<<< HEAD
-=======
- * @tparam _INSTRUMENT                  Whether or not we want instrumentation
-logic generated
->>>>>>> dev-intersection-op
  * @tparam _MIN_CTA_OCCUPANCY           Lower bound on number of CTAs to have
 resident per SM (influences per-CTA smem cache sizes and register
 allocation/spills).
@@ -95,7 +88,7 @@ struct KernelPolicy {
    */
   struct SmemStorage {
     enum {
-      MAX_SCRATCH_BYTES_PER_CTA = GR_SMEM_BYTES(CUDA_ARCH) / MIN_CTA_OCCUPANCY,
+      MAX_SCRATCH_BYTES_PER_CTA = GR_SMEM_BYTES(GR_CUDA_ARCH) / MIN_CTA_OCCUPANCY,
 
       SCRATCH_ELEMENT_SIZE = sizeof(SizeT),
 
@@ -111,10 +104,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MIN_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
     VALID = (CTA_OCCUPANCY > 0),
   };

--- a/gunrock/oprtr/oprtr_base.cuh
+++ b/gunrock/oprtr/oprtr_base.cuh
@@ -50,10 +50,6 @@ static const util::io::ld::CacheModifier ROW_OFFSET_UNALIGNED_READ_MODIFIER =
 static const util::io::st::CacheModifier QUEUE_WRITE_MODIFIER =
     util::io::st::cg;
 
-#ifndef CUDA_ARCH
-static const int CUDA_ARCH = 300;  // CUDA_ARCH compiled for
-#endif
-
 /**
  * @brief Operator Modes
  */

--- a/gunrock/oprtr/simplified2_filter/kernel.cuh
+++ b/gunrock/oprtr/simplified2_filter/kernel.cuh
@@ -30,7 +30,13 @@ namespace simplified2_filter {
  * @tparam VALID.
  */
 template <typename KernelPolicy, typename Problem, typename Functor,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID =
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {};
 
 template <typename KernelPolicy, typename Problem, typename Functor>

--- a/gunrock/oprtr/simplified2_filter/kernel_policy.cuh
+++ b/gunrock/oprtr/simplified2_filter/kernel_policy.cuh
@@ -21,9 +21,6 @@ namespace oprtr {
 namespace simplified2_filter {
 
 template <typename _Problem,
-
-          // Machine parameters
-          int _CUDA_ARCH,
           // bool _INSTRUMENT,
           // Behavioral control parameters
           int _SATURATION_QUIT, bool _DEQUEUE_PROBLEM_SIZE,
@@ -34,7 +31,7 @@ template <typename _Problem,
           int _END_BITMASK_CULL, int _LOG_SCHEDULE_GRANULARITY, int _MODE>
 struct KernelPolicy
     : public gunrock::oprtr::cull_filter::KernelPolicy<
-          _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+          _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
           _MIN_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE,
           _LOG_LOADS_PER_TILE, _LOG_RAKING_THREADS, _END_BITMASK_CULL,
           _LOG_SCHEDULE_GRANULARITY, _MODE> {

--- a/gunrock/oprtr/simplified_advance/kernel.cuh
+++ b/gunrock/oprtr/simplified_advance/kernel.cuh
@@ -39,7 +39,13 @@ template <typename KernelPolicy, typename ProblemData, typename Functor,
           gunrock::oprtr::advance::TYPE ADVANCE_TYPE,
           gunrock::oprtr::advance::REDUCE_TYPE R_TYPE,
           gunrock::oprtr::advance::REDUCE_OP R_OP,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID =
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {};
 
 /*

--- a/gunrock/oprtr/simplified_advance/kernel_policy.cuh
+++ b/gunrock/oprtr/simplified_advance/kernel_policy.cuh
@@ -30,8 +30,6 @@ namespace simplified_advance {
  * architectures and problem types.
  *
  * @tparam _ProblemData                 Problem data type.
- * @tparam _CUDA_ARCH                   CUDA SM architecture to generate code
- * for.
  * @tparam _INSTRUMENT                  Whether or not we want instrumentation
  * logic generated
  * @tparam _MIN_CTA_OCCUPANCY           Lower bound on number of CTAs to have
@@ -40,8 +38,6 @@ namespace simplified_advance {
  * @tparam _LOG_THREADS                 Number of threads per CTA (log).
  */
 template <typename _ProblemData,
-          // Machine parameters
-          int _CUDA_ARCH,
           // Tunable parameters
           int _MIN_CTA_OCCUPANCY, int _LOG_THREADS, int _LOG_BLOCKS,
           int _LIGHT_EDGE_THRESHOLD>
@@ -57,8 +53,6 @@ struct KernelPolicy {
   typedef typename ProblemData::Value Value;
 
   enum {
-
-    CUDA_ARCH = _CUDA_ARCH,
     LOG_THREADS = _LOG_THREADS,
     THREADS = 1 << LOG_THREADS,
     LOG_BLOCKS = _LOG_BLOCKS,
@@ -84,10 +78,10 @@ struct KernelPolicy {
   };
 
   enum {
-    THREAD_OCCUPANCY = GR_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
-    SMEM_OCCUPANCY = GR_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+    THREAD_OCCUPANCY = GR_SM_THREADS(GR_CUDA_ARCH) >> LOG_THREADS,
+    SMEM_OCCUPANCY = GR_SMEM_BYTES(GR_CUDA_ARCH) / sizeof(SmemStorage),
     CTA_OCCUPANCY = GR_MIN(_MIN_CTA_OCCUPANCY,
-                           GR_MIN(GR_SM_CTAS(CUDA_ARCH),
+                           GR_MIN(GR_SM_CTAS(GR_CUDA_ARCH),
                                   GR_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY))),
 
     VALID = (CTA_OCCUPANCY > 0),

--- a/gunrock/oprtr/simplified_filter/kernel.cuh
+++ b/gunrock/oprtr/simplified_filter/kernel.cuh
@@ -30,7 +30,13 @@ namespace oprtr {
 namespace simplified_filter {
 
 template <typename KernelPolicy, typename Problem, typename Functor,
-          bool VALID = (__GR_CUDA_ARCH__ >= KernelPolicy::CUDA_ARCH)>
+          bool VALID =
+#ifdef __CUDA_ARCH__
+              true
+#else
+              false
+#endif
+          >
 struct Dispatch {};
 
 template <typename KernelPolicy, typename Problem, typename Functor>

--- a/gunrock/oprtr/simplified_filter/kernel_policy.cuh
+++ b/gunrock/oprtr/simplified_filter/kernel_policy.cuh
@@ -21,9 +21,6 @@ namespace oprtr {
 namespace simplified_filter {
 
 template <typename _Problem,
-
-          // Machine parameters
-          int _CUDA_ARCH,
           // bool _INSTRUMENT,
           // Behavioral control parameters
           int _SATURATION_QUIT, bool _DEQUEUE_PROBLEM_SIZE,
@@ -34,7 +31,7 @@ template <typename _Problem,
           int _END_BITMASK_CULL, int _LOG_SCHEDULE_GRANULARITY, int _MODE>
 struct KernelPolicy
     : public gunrock::oprtr::cull_filter::KernelPolicy<
-          _Problem, _CUDA_ARCH, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
+          _Problem, _SATURATION_QUIT, _DEQUEUE_PROBLEM_SIZE,
           _MIN_CTA_OCCUPANCY, _LOG_THREADS, _LOG_LOAD_VEC_SIZE,
           _LOG_LOADS_PER_TILE, _LOG_RAKING_THREADS, _END_BITMASK_CULL,
           _LOG_SCHEDULE_GRANULARITY, _MODE> {

--- a/gunrock/util/cuda_properties.cuh
+++ b/gunrock/util/cuda_properties.cuh
@@ -14,21 +14,26 @@
 
 #pragma once
 
-namespace gunrock {
-namespace util {
-
 /*****************************************************************
  * Macros for guiding compilation paths
  *****************************************************************/
 
 /**
  * CUDA architecture of the current compilation path
+ *
+ * When compiling nvcc sets the __CUDA_ARCH__ environment variable
+ * to the current compute capability being compiled for.
+ * We set GR_CUDA_ARCH to this value if it's available and 300
+ * otherwise (in host-side code)
  */
-#ifndef __CUDA_ARCH__
-//#define __GR_CUDA_ARCH__ 0                      // Host path
+#ifdef __CUDA_ARCH__ // Device-side compilation
+#define GR_CUDA_ARCH __CUDA_ARCH__
 #else
-#define __GR_CUDA_ARCH__ __CUDA_ARCH__  // Device path
+#define GR_CUDA_ARCH 300 // Host-side compilation
 #endif
+
+namespace gunrock {
+namespace util {
 
 /*****************************************************************
  * Device properties by SM architectural version


### PR DESCRIPTION
Many operators currently do occupancy calculations using the variable
CUDA_ARCH. This value is hard-coded in multiple places to be 300.
This change disambiguates multiple overlapping uses of the variable,
and ensures that it uses the currently compiling compute capability.
This allows occupancy calculations to use the correct numbers and
eliminates some build warnings when compiling with RTX cards.

Some of the KernelPolicy structs defined by operators use a template
variable _CUDA_ARCH (note the leading underscore). These variables
are hard-coded to 300 by their template typedefs. Other KernelPolicy
structs simply use CUDA_ARCH, which will pick up the static
definition in oprtr_base.h

All uses of CUDA_ARCH will now point to a global value GR_CUDA_ARCH
defined in cuda_properties.cuh rather than have this ambiguous
behavior. It also sets this value based on the currently compiling
compute capability. When compiling host device code, it will use the
value of 300, as the actual value should be irrelevant during these
passes.