### PR TITLE
Upgrading Gunrock's dependency to moderngpu 2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "externals/moderngpu"]
 	path = externals/moderngpu
 	url = https://github.com/NVlabs/moderngpu.git
-	branch = branch_1.1
+	branch = master
 [submodule "docs"]
 	path = docs
 	url = https://github.com/gunrock/docs.git

--- a/cmake/FindModernGPU.cmake
+++ b/cmake/FindModernGPU.cmake
@@ -2,11 +2,11 @@
 #  Gunrock: Find external moderngpu directories
 # ------------------------------------------------------------------------
 SET(mgpu_INCLUDE_DIRS
-  ${CMAKE_SOURCE_DIR}/externals/moderngpu/include
+  ${CMAKE_SOURCE_DIR}/externals/moderngpu/src
   CACHE PATH
   "Directory to the Modern GPU include files")
 
 SET(mgpu_SOURCE_DIRS
-  ${CMAKE_SOURCE_DIR}/externals/moderngpu/src
+  ${CMAKE_SOURCE_DIR}/externals/moderngpu/src/moderngpu
   CACHE PATH
   "Directory to the Modern GPU source files")

--- a/cmake/SetSubProject.cmake
+++ b/cmake/SetSubProject.cmake
@@ -18,8 +18,7 @@ else()
 endif()
 
 set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
+  ${mgpu_SOURCE_DIRS}/context.hxx)
 # end /* moderngpu include directories */
 
 # begin /* CUB include directories */

--- a/examples/BaseMakefile.mk
+++ b/examples/BaseMakefile.mk
@@ -54,7 +54,7 @@ SM_TARGETS = $(GEN_SM70)
 #-------------------------------------------------------------------------------
 
 CUDA_INC = -I"$(shell dirname $(NVCC))/../include"
-MGPU_INC = -I"../../externals/moderngpu/include"
+MGPU_INC = -I"../../externals/moderngpu/src"
 CUB_INC = -I"../../externals/cub"
 
 BOOST_INC =
@@ -132,9 +132,8 @@ endif
 EXTRA_SOURCE_ = ../../gunrock/util/str_to_T.cu \
 	../../gunrock/util/test_utils.cu \
 	../../gunrock/util/error_utils.cu \
-	../../externals/moderngpu/src/mgpucontext.cu \
-	../../externals/moderngpu/src/mgpuutil.cpp \
 	../../gunrock/util/gitsha1make.c
+	# ../../externals/moderngpu/src/moderngpu/context.hxx \
 
 ifeq (DARWIN, $(findstring DARWIN, $(OSUPPER)))
     EXTRA_SOURCE = $(EXTRA_SOURCE_) \

--- a/gunrock/CMakeLists.txt
+++ b/gunrock/CMakeLists.txt
@@ -21,8 +21,7 @@ else()
 endif()
 
 set (mgpu_SOURCE_FILES
-  ${mgpu_SOURCE_DIRS}/mgpucontext.cu
-  ${mgpu_SOURCE_DIRS}/mgpuutil.cpp)
+  ${mgpu_SOURCE_DIRS}/context.hxx)
 
 set(HFILES_PUBLIC
   gunrock.h)

--- a/gunrock/app/enactor_loop.cuh
+++ b/gunrock/app/enactor_loop.cuh
@@ -20,7 +20,6 @@
 #include <gunrock/app/enactor_kernel.cuh>
 #include <gunrock/app/enactor_helper.cuh>
 #include <gunrock/util/latency_utils.cuh>
-#include <moderngpu.cuh>
 
 /* this is the "stringize macro macro" hack */
 #define STR(x) #x

--- a/gunrock/app/enactor_types.cuh
+++ b/gunrock/app/enactor_types.cuh
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <time.h>
-#include <moderngpu.cuh>
+// #include <moderngpu/context.hxx>
 #include <gunrock/util/multithreading.cuh>
 #include <gunrock/util/kernel_runtime_stats.cuh>
 #include <gunrock/util/parameters.h>
@@ -235,7 +235,7 @@ class EnactorSlice {
   typedef oprtr::OprtrParameters<GraphT, FrontierT, LabelT> OprtrParametersT;
 
   cudaStream_t stream, stream2;
-  mgpu::ContextPtr context;
+  // mgpu::standard_context_t context;
   EnactorStats<SizeT> enactor_stats;
   FrontierT frontier;
   OprtrParametersT oprtr_parameters;
@@ -266,7 +266,7 @@ class EnactorSlice {
 
       int gpu_idx;
       GUARD_CU2(cudaGetDevice(&gpu_idx), "cudaGetDevice failed.");
-      context = mgpu::CreateCudaDeviceAttachStream(gpu_idx, stream);
+      // context.stream(stream); // = stream;
       // util::PrintMsg("Stream and context allocated on GPU " +
       // std::to_string(gpu_idx));
     }
@@ -276,7 +276,7 @@ class EnactorSlice {
     GUARD_CU(oprtr_parameters.Init());
 
     oprtr_parameters.stream = stream;
-    oprtr_parameters.context = context;
+    // oprtr_parameters.context = context;
     oprtr_parameters.frontier = &frontier;
     oprtr_parameters.cuda_props = cuda_properties;
     oprtr_parameters.advance_mode = advance_mode;

--- a/gunrock/oprtr/LB_CULL_advance/kernel.cuh
+++ b/gunrock/oprtr/LB_CULL_advance/kernel.cuh
@@ -17,6 +17,7 @@
 #include <gunrock/util/cta_work_progress.cuh>
 #include <gunrock/util/kernel_runtime_stats.cuh>
 #include <gunrock/util/device_intrinsics.cuh>
+#include <gunrock/util/sorted_search.cuh>
 
 //#include <gunrock/oprtr/edge_map_partitioned/kernel.cuh>
 //#include <gunrock/oprtr/cull_filter/cta.cuh>
@@ -1093,13 +1094,14 @@ cudaError_t Launch_CSR_CSC(const GraphT &graph, const FrontierInT *frontier_in,
     oprtr::SetIdx_Kernel<<<1, 256, 0, parameters.stream>>>(
         parameters.frontier->block_output_starts.GetPointer(util::DEVICE),
         outputs_per_block, num_blocks);
-    mgpu::SortedSearch<mgpu::MgpuBoundsLower>(
-        parameters.frontier->block_output_starts.GetPointer(util::DEVICE),
-        num_blocks,
-        parameters.frontier->output_offsets.GetPointer(util::DEVICE),
-        parameters.frontier->queue_length,
-        parameters.frontier->block_input_starts.GetPointer(util::DEVICE),
-        parameters.context[0]);
+
+    util::SortedSearch(
+      parameters.frontier->block_output_starts,
+      (SizeT)num_blocks,
+      parameters.frontier->output_offsets,
+      (SizeT)parameters.frontier->queue_length,
+      parameters.frontier->block_input_starts,
+      parameters.context);
 
     RelaxPartitionedEdges2<FLAG, GraphT, InKeyT, OutKeyT, ValueT, LabelT>
         <<<num_blocks, KernelPolicyT::THREADS, 0, parameters.stream>>>(

--- a/gunrock/oprtr/advance/advance_base.cuh
+++ b/gunrock/oprtr/advance/advance_base.cuh
@@ -17,6 +17,7 @@
 #include <gunrock/oprtr/1D_oprtr/1D_scalar.cuh>
 #include <gunrock/oprtr/oprtr_base.cuh>
 #include <gunrock/oprtr/oprtr_parameters.cuh>
+#include <gunrock/util/scan_device.cuh>
 
 namespace gunrock {
 namespace oprtr {
@@ -178,14 +179,11 @@ cudaError_t ComputeOutputLength(const GraphT graph,
   // util::DisplayDeviceResults(partitioned_scanned_edges,
   // frontier_attribute->queue_length);
 
-  mgpu::Scan<mgpu::MgpuScanTypeInc>(
-      parameters.frontier->output_offsets.GetPointer(util::DEVICE),
-      parameters.frontier->queue_length,  // TODO: +1?
-      (SizeT)0, mgpu::plus<SizeT>(),
-      parameters.frontier->output_length.GetPointer(util::DEVICE),
-      (SizeT *)NULL,
-      parameters.frontier->output_offsets.GetPointer(util::DEVICE),
-      parameters.context[0]);
+  util::Scan(parameters.frontier->output_offsets,  // Input
+    parameters.frontier->queue_length,    // Num_Items
+    parameters.frontier->output_offsets,  // Output
+    parameters.frontier->output_length.GetPointer(util::DEVICE), //); // Reduction It.
+    parameters.context);
 
   return retval;
 }

--- a/gunrock/oprtr/intersection/kernel.cuh
+++ b/gunrock/oprtr/intersection/kernel.cuh
@@ -25,8 +25,6 @@
 #include <gunrock/oprtr/intersection/cta.cuh>
 
 #include <gunrock/oprtr/intersection/kernel_policy.cuh>
-#include <cub/cub.cuh>
-#include <moderngpu.cuh>
 #include <gunrock/util/test_utils.cuh>
 
 namespace gunrock {

--- a/gunrock/oprtr/oprtr_parameters.cuh
+++ b/gunrock/oprtr/oprtr_parameters.cuh
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <moderngpu.cuh>
 #include <gunrock/app/frontier.cuh>
 #include <gunrock/oprtr/oprtr_base.cuh>
+#include <moderngpu/context.hxx>
 
 namespace gunrock {
 namespace oprtr {
@@ -45,8 +45,11 @@ struct OprtrParameters {
   // bool    *d_backward_frontier_map_out;
   // SizeT         max_in;
   // SizeT         max_out;
-  mgpu::ContextPtr context;
   cudaStream_t stream;
+
+  // TODO: Attach stream to the context
+  mgpu::standard_context_t context;
+
   bool get_output_length;
   bool reduce_reset;
   std::string advance_mode;

--- a/gunrock/oprtr/oprtr_parameters.cuh
+++ b/gunrock/oprtr/oprtr_parameters.cuh
@@ -59,7 +59,9 @@ struct OprtrParameters {
   LabelT label;
   int max_grid_size;
 
-  OprtrParameters() { Init(); }
+  // Set print_prop to false to hide output
+  OprtrParameters() : context(false)
+    { Init(); }
 
   ~OprtrParameters() { Init(); }
 

--- a/gunrock/util/scan_device.cuh
+++ b/gunrock/util/scan_device.cuh
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <cub/cub.cuh>
+#include <moderngpu/kernel_scan.hxx>
 #include <gunrock/util/array_utils.cuh>
 
 namespace gunrock {
@@ -52,6 +53,26 @@ cudaError_t cubInclusiveSum(util::Array1D<uint64_t, char> &cub_temp_space,
       stream, debug_synchronous);
 
   if (retval) return retval;
+
+  return retval;
+}
+
+template <typename InputT, typename OutputT, 
+          typename ReduceT, typename SizeT>
+cudaError_t Scan(util::Array1D<SizeT, InputT> &d_in, SizeT num_items,
+                 util::Array1D<SizeT, OutputT> &d_out,
+                 ReduceT *r, mgpu::context_t &context,
+                 bool debug_synchronous = false) {
+
+  cudaError_t retval = cudaSuccess; 
+//   cudaStream_t stream = 0;
+//   mgpu::standard_context_t context(false, stream);
+  mgpu::scan<mgpu::scan_type_inc>(d_in.GetPointer(util::DEVICE), num_items, 
+                                  d_out.GetPointer(util::DEVICE),
+                                  mgpu::plus_t<InputT>(), r,
+                                  context);
+
+  if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
 
   return retval;
 }

--- a/gunrock/util/scan_device.cuh
+++ b/gunrock/util/scan_device.cuh
@@ -67,7 +67,19 @@ cudaError_t Scan(util::Array1D<SizeT, InputT> &d_in, SizeT num_items,
   cudaError_t retval = cudaSuccess; 
 //   cudaStream_t stream = 0;
 //   mgpu::standard_context_t context(false, stream);
-  mgpu::scan<mgpu::scan_type_inc>(d_in.GetPointer(util::DEVICE), num_items, 
+
+  // TODO: Experiment with these values and choose the best ones. We
+  // could even choose to make them a parameter of util::Scan and choose
+  // based on our usage
+  typedef mgpu::launch_box_t<
+      mgpu::arch_30_cta<256, 7>,
+      mgpu::arch_35_cta<256, 7>,
+      mgpu::arch_50_cta<256, 7>,
+      mgpu::arch_60_cta<256, 7>,
+      mgpu::arch_70_cta<256, 7>,
+      mgpu::arch_75_cta<256, 7>
+      > launch_t;
+  mgpu::scan<mgpu::scan_type_inc, launch_t>(d_in.GetPointer(util::DEVICE), num_items,
                                   d_out.GetPointer(util::DEVICE),
                                   mgpu::plus_t<InputT>(), r,
                                   context);

--- a/gunrock/util/sorted_search.cuh
+++ b/gunrock/util/sorted_search.cuh
@@ -1,0 +1,61 @@
+// ----------------------------------------------------------------
+// Gunrock -- Fast and Efficient GPU Graph Library
+// ----------------------------------------------------------------
+// This source code is distributed under the terms of LICENSE.TXT
+// in the root directory of this source distribution.
+// ----------------------------------------------------------------
+
+/**
+ * @file
+ * search_utils.cuh
+ *
+ * @brief kernel utils used for search.
+ */
+
+ #pragma once
+ #include <cub/cub.cuh>
+ #include <gunrock/util/array_utils.cuh>
+ #include <moderngpu/kernel_sortedsearch.hxx>
+ 
+ namespace gunrock {
+ namespace util {
+ 
+ /**
+  * \addtogroup PublicInterface
+  * @{
+  */
+ 
+ //---------------------------------------------------------------------
+ // Globals, constants and typedefs
+ //---------------------------------------------------------------------
+
+template <typename A, typename B, typename C, typename SizeT>
+cudaError_t SortedSearch(util::Array1D<SizeT, A> &needles, SizeT num_needles,
+                        util::Array1D<SizeT, B> &haystack, SizeT num_haystack,
+                        util::Array1D<SizeT, C> &indices,
+                        mgpu::context_t &context,
+                        bool debug_synchronous = false) {
+  
+cudaError_t retval = cudaSuccess;
+ 
+mgpu::sorted_search<mgpu::bounds_lower>(needles.GetPointer(util::DEVICE), num_needles, 
+                                        haystack.GetPointer(util::DEVICE), num_haystack, 
+                                        indices.GetPointer(util::DEVICE), mgpu::less_t<A>(), 
+                                        context);
+
+if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
+
+return retval;
+}
+ 
+ /** @} */
+ 
+ }  // namespace util
+ }  // namespace gunrock
+ 
+ // Leave this at the end of the file
+ // Local Variables:
+ // mode:c++
+ // c-file-style: "NVIDIA"
+ // End:
+ 

--- a/gunrock/util/sorted_search.cuh
+++ b/gunrock/util/sorted_search.cuh
@@ -6,28 +6,28 @@
 // ----------------------------------------------------------------
 
 /**
- * @file
- * search_utils.cuh
- *
- * @brief kernel utils used for search.
+* @file
+* search_utils.cuh
+*
+* @brief kernel utils used for search.
+*/
+
+#pragma once
+#include <cub/cub.cuh>
+#include <gunrock/util/array_utils.cuh>
+#include <moderngpu/kernel_sortedsearch.hxx>
+
+namespace gunrock {
+namespace util {
+
+/**
+ * \addtogroup PublicInterface
+ * @{
  */
 
- #pragma once
- #include <cub/cub.cuh>
- #include <gunrock/util/array_utils.cuh>
- #include <moderngpu/kernel_sortedsearch.hxx>
- 
- namespace gunrock {
- namespace util {
- 
- /**
-  * \addtogroup PublicInterface
-  * @{
-  */
- 
- //---------------------------------------------------------------------
- // Globals, constants and typedefs
- //---------------------------------------------------------------------
+//---------------------------------------------------------------------
+// Globals, constants and typedefs
+//---------------------------------------------------------------------
 
 template <typename A, typename B, typename C, typename SizeT>
 cudaError_t SortedSearch(util::Array1D<SizeT, A> &needles, SizeT num_needles,
@@ -35,27 +35,38 @@ cudaError_t SortedSearch(util::Array1D<SizeT, A> &needles, SizeT num_needles,
                         util::Array1D<SizeT, C> &indices,
                         mgpu::context_t &context,
                         bool debug_synchronous = false) {
-  
-cudaError_t retval = cudaSuccess;
- 
-mgpu::sorted_search<mgpu::bounds_lower>(needles.GetPointer(util::DEVICE), num_needles, 
-                                        haystack.GetPointer(util::DEVICE), num_haystack, 
-                                        indices.GetPointer(util::DEVICE), mgpu::less_t<A>(), 
-                                        context);
 
-if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
+  cudaError_t retval = cudaSuccess;
 
-return retval;
+  // TODO: Experiment with these values and choose the best ones. We
+  // could even choose to make them a parameter of util::SortedSearch
+  // and choose based on our usage
+  typedef mgpu::launch_box_t<
+      mgpu::arch_30_cta<256, 7>,
+      mgpu::arch_35_cta<256, 7>,
+      mgpu::arch_50_cta<256, 7>,
+      mgpu::arch_60_cta<256, 7>,
+      mgpu::arch_70_cta<256, 7>,
+      mgpu::arch_75_cta<256, 7>
+      > launch_t;
+
+  mgpu::sorted_search<mgpu::bounds_lower, launch_t>(needles.GetPointer(util::DEVICE), num_needles,
+                                                    haystack.GetPointer(util::DEVICE), num_haystack,
+                                                    indices.GetPointer(util::DEVICE), mgpu::less_t<A>(),
+                                                    context);
+
+  if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
+
+  return retval;
 }
- 
- /** @} */
- 
- }  // namespace util
- }  // namespace gunrock
- 
- // Leave this at the end of the file
- // Local Variables:
- // mode:c++
- // c-file-style: "NVIDIA"
- // End:
- 
+
+/** @} */
+
+}  // namespace util
+}  // namespace gunrock
+
+// Leave this at the end of the file
+// Local Variables:
+// mode:c++
+// c-file-style: "NVIDIA"
+// End:


### PR DESCRIPTION
Preparing for the refactor, for which I use moderngpu 2 instead of 1. Hoping to get some a nice performance improvements with the following changes and the fixes issued in PR #673.

## TODO
- [x] Update moderngpu's [launchbox ](https://github.com/moderngpu/moderngpu/wiki/Launching-kernels#launch-box) to support `SM > 53`
- [x] Bug somewhere in a shfl_sync primitive of moderngpu causing a hang in some apps
- [x] Silence the output of `mgpu::context_t()`