### PR TITLE
Fix for pagerank illegal memory access

### DIFF
--- a/gunrock/app/pr/pr_test.cuh
+++ b/gunrock/app/pr/pr_test.cuh
@@ -94,7 +94,7 @@ cudaError_t Compensate_ZeroDegrees(GraphT &graph, bool quiet = false) {
   CooT new_coo;
   GUARD_CU(new_coo.Allocate(graph_coo.nodes + 1,
                             graph_coo.edges + counter + graph_coo.nodes,
-                            util::HOST));
+                            util::HOST | util::DEVICE));
   GUARD_CU(new_coo.edge_pairs.ForEach(
       graph_coo.edge_pairs,
       [] __host__ __device__(EdgePairT & new_pair, const EdgePairT &old_pair) {

--- a/gunrock/util/test_utils.cu
+++ b/gunrock/util/test_utils.cu
@@ -17,6 +17,29 @@
 namespace gunrock {
 namespace util {
 
+bool IsDevicePointer(const void *ptr)
+{
+    cudaPointerAttributes attributes;
+    auto err = cudaPointerGetAttributes(&attributes, ptr);
+
+    // An error here indicates the memory was LIKELY
+    // allocated on the host or the pointer is gibberish.
+    if(err != cudaSuccess)
+    {
+        // Clear out the last cuda error. We expected this error
+        // because it implies we have a host side pointer.
+        cudaGetLastError();
+        return false;
+    }
+
+    if(attributes.devicePointer != nullptr)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 /******************************************************************************
  * Device initialization
  ******************************************************************************/

--- a/gunrock/util/test_utils.h
+++ b/gunrock/util/test_utils.h
@@ -47,6 +47,17 @@
 namespace gunrock {
 namespace util {
 
+/**
+ * Do we have a host or device side pointer?
+ * 
+ * Return true if the given ptr was allocated on device, 
+ * false if on the host. 
+ * 
+ * More info:
+ * https://stackoverflow.com/questions/50116861/why-is-cudapointergetattributes-returning-invalid-argument-for-host-pointer
+ */
+bool IsDevicePointer(const void *ptr);
+
 /******************************************************************************
  * Command-line parsing functionality
  ******************************************************************************/

--- a/unittests/test_pointer_location.h
+++ b/unittests/test_pointer_location.h
@@ -1,0 +1,61 @@
+/*
+ * @brief Test to determine the location (device or host) of memory
+ * @file test_pointer_location.h
+ */
+
+#include <gunrock/util/test_utils.h>
+
+// #include <cuda.h>
+// #include <cuda_runtime_api.h> 
+
+// bool IsDevicePointer(const void *ptr)
+// {
+//     cudaPointerAttributes attributes;
+
+//     auto err = cudaPointerGetAttributes(&attributes, ptr);
+
+//     // An error here indicates the pointer was LIKELY
+//     // allocated on the host or the pointer is gibberish.
+//     // More info here: 
+//     // https://stackoverflow.com/questions/50116861/why-is-cudapointergetattributes-returning-invalid-argument-for-host-pointer
+//     if(err != cudaSuccess)
+//     {
+//         // fprintf(stderr, "Cuda error %d %s:: %s\n", __LINE__, __func__, cudaGetErrorString(err));
+//         // Clear out the last cuda error. We expected this error
+//         // because it implies we have a host side pointer.
+//         cudaGetLastError();
+//         return false;
+//     }
+
+//     if(attributes.devicePointer != nullptr)
+//     {
+//         return true;
+//     }
+
+//     return false;
+// }
+
+
+TEST(utils, PointerLocation) 
+{
+    using namespace gunrock::util;
+
+    //
+    // pointers to host memory
+    
+    int x = 10;
+    auto host_ptr = &x;
+    EXPECT_EQ(false, IsDevicePointer(host_ptr));
+
+    auto host_ptr2 = (int*)malloc(256 * sizeof(int));
+    EXPECT_EQ(false, IsDevicePointer(host_ptr2));
+    free(host_ptr2);
+
+    //
+    // pointers to device memory
+    
+    int *device_ptr = nullptr;
+    cudaMalloc((void **)&device_ptr, 1024);
+    EXPECT_EQ(true, IsDevicePointer(device_ptr));
+    cudaFree((void*)device_ptr);
+}

--- a/unittests/test_pointer_location.h
+++ b/unittests/test_pointer_location.h
@@ -5,37 +5,6 @@
 
 #include <gunrock/util/test_utils.h>
 
-// #include <cuda.h>
-// #include <cuda_runtime_api.h> 
-
-// bool IsDevicePointer(const void *ptr)
-// {
-//     cudaPointerAttributes attributes;
-
-//     auto err = cudaPointerGetAttributes(&attributes, ptr);
-
-//     // An error here indicates the pointer was LIKELY
-//     // allocated on the host or the pointer is gibberish.
-//     // More info here: 
-//     // https://stackoverflow.com/questions/50116861/why-is-cudapointergetattributes-returning-invalid-argument-for-host-pointer
-//     if(err != cudaSuccess)
-//     {
-//         // fprintf(stderr, "Cuda error %d %s:: %s\n", __LINE__, __func__, cudaGetErrorString(err));
-//         // Clear out the last cuda error. We expected this error
-//         // because it implies we have a host side pointer.
-//         cudaGetLastError();
-//         return false;
-//     }
-
-//     if(attributes.devicePointer != nullptr)
-//     {
-//         return true;
-//     }
-
-//     return false;
-// }
-
-
 TEST(utils, PointerLocation) 
 {
     using namespace gunrock::util;

--- a/unittests/test_unittests.cu
+++ b/unittests/test_unittests.cu
@@ -37,13 +37,15 @@
 #include "test_lib_sm.h"
 
 // Tests the RepeatFor Operator
-#include "test_repeatfor.h"
+ #include "test_repeatfor.h"
 
 // Tests Segmented Reduction (device)
 #include "test_segreduce.h"
 
 // Tests Binary Search
 #include "test_binarysearch.h"
+
+#include "test_pointer_location.h"
 
 using namespace gunrock;
 


### PR DESCRIPTION
The fix is in `pr_test.cuh` (was missing `util::DEVICE` in `new_coo` allocation).

Runs like: `./pr --graph-scale 20 --graph-type rmat --graph-edgefactor 32` (from duplicate issue #629) complete as expected.

The additional commits add a utility (and associated gtest) that helped me generate some stack traces during debugging.