### PR TITLE
opt in warnings nvcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,12 @@ endif (CUDA_VERBOSE_PTXAS)
 set(CUDA_NVCC_FLAGS --expt-extended-lambda -rdc=true -lcudadevrt)
 set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_curand_LIBRARY})
 
+# begin /* Suppress all warnings from nvcc */
+if (NOT ENABLE_WARNINGS)
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -w")
+endif (NOT ENABLE_WARNINGS)
+# end /* Suppress all warnings from nvcc */
+
 if(GUNROCK_BUILD_LIB)
   if(GUNROCK_BUILD_SHARED_LIBS)
     set(LIB_TYPE SHARED)


### PR DESCRIPTION
Related to #689 

Please note that this only mimics what is currently done with gcc (disable warning when ENABLE WARNINGS is off). I did not check all warnings shown by nvcc when building. Some seemed fine (converting -1 to unsigned), some can be an issue (using a printf %d to print a templatized variable)