### PR TITLE
Prevent duplication of key "load-time" in output json

### DIFF
--- a/gunrock/util/info_rapidjson.cuh
+++ b/gunrock/util/info_rapidjson.cuh
@@ -183,7 +183,6 @@ struct Info {
     SetVal("time", time_str);
     SetVal("gunrock-version", XSTR(GUNROCKVERSION));
     SetVal("git-commit-sha", g_GIT_SHA1);
-    // SetVal("load-time", parameters.Get<float>("load-time"));
     SetVal("primitive", algorithm_name);
 
     SetVal("stddev-degree", graph::GetStddevDegree(graph));

--- a/gunrock/util/info_rapidjson.cuh
+++ b/gunrock/util/info_rapidjson.cuh
@@ -183,7 +183,7 @@ struct Info {
     SetVal("time", time_str);
     SetVal("gunrock-version", XSTR(GUNROCKVERSION));
     SetVal("git-commit-sha", g_GIT_SHA1);
-    SetVal("load-time", parameters.Get<float>("load-time"));
+    // SetVal("load-time", parameters.Get<float>("load-time"));
     SetVal("primitive", algorithm_name);
 
     SetVal("stddev-degree", graph::GetStddevDegree(graph));


### PR DESCRIPTION
@crozhon  I still haven't figured out where the second ```setVal()``` for **load-time** is being called, but commenting out this one works!