### PR TITLE
Fix mgpu memory issues from seperate stream

### DIFF
--- a/gunrock/app/enactor_types.cuh
+++ b/gunrock/app/enactor_types.cuh
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <time.h>
-// #include <moderngpu/context.hxx>
+#include <moderngpu/context.hxx>
 #include <gunrock/util/multithreading.cuh>
 #include <gunrock/util/kernel_runtime_stats.cuh>
 #include <gunrock/util/parameters.h>
@@ -235,7 +235,6 @@ class EnactorSlice {
   typedef oprtr::OprtrParameters<GraphT, FrontierT, LabelT> OprtrParametersT;
 
   cudaStream_t stream, stream2;
-  // mgpu::standard_context_t context;
   EnactorStats<SizeT> enactor_stats;
   FrontierT frontier;
   OprtrParametersT oprtr_parameters;
@@ -273,10 +272,9 @@ class EnactorSlice {
 
     GUARD_CU(enactor_stats.Init(target));
     GUARD_CU(frontier.Init(num_queues, types, frontier_name, target));
-    GUARD_CU(oprtr_parameters.Init());
+    GUARD_CU(oprtr_parameters.Init(stream));
 
-    oprtr_parameters.stream = stream;
-    // oprtr_parameters.context = context;
+    // Create moderngpu context
     oprtr_parameters.frontier = &frontier;
     oprtr_parameters.cuda_props = cuda_properties;
     oprtr_parameters.advance_mode = advance_mode;

--- a/gunrock/oprtr/oprtr_parameters.cuh
+++ b/gunrock/oprtr/oprtr_parameters.cuh
@@ -20,77 +20,75 @@
 
 namespace gunrock {
 namespace oprtr {
+    template <typename GraphT, typename FrontierT, typename _LabelT>
+    struct OprtrParameters {
+        typedef typename GraphT::VertexT VertexT;
+        typedef typename GraphT::SizeT SizeT;
+        typedef typename GraphT::ValueT ValueT;
+        typedef _LabelT LabelT;
 
-template <typename GraphT, typename FrontierT, typename _LabelT>
-struct OprtrParameters {
-  typedef typename GraphT::VertexT VertexT;
-  typedef typename GraphT::SizeT SizeT;
-  typedef typename GraphT::ValueT ValueT;
-  typedef _LabelT LabelT;
+        FrontierT *frontier;
+        util::Array1D<SizeT, ValueT> *values_in;
+        util::Array1D<SizeT, ValueT> *values_out;
+        util::Array1D<SizeT, ValueT> *reduce_values_temp;
+        util::Array1D<SizeT, ValueT> *reduce_values_temp2;
+        util::Array1D<SizeT, ValueT> *reduce_values_out;
+        util::Array1D<SizeT, SizeT> *vertex_markers;
+        util::Array1D<SizeT, unsigned char> *visited_masks;
+        util::Array1D<SizeT, LabelT> *labels;
+        util::CudaProperties *cuda_props;
 
-  // app::EnactorStats     <SizeT> *enactor_stats;
-  FrontierT *frontier;
-  util::Array1D<SizeT, ValueT> *values_in;
-  util::Array1D<SizeT, ValueT> *values_out;
-  util::Array1D<SizeT, ValueT> *reduce_values_temp;
-  util::Array1D<SizeT, ValueT> *reduce_values_temp2;
-  util::Array1D<SizeT, ValueT> *reduce_values_out;
-  util::Array1D<SizeT, SizeT> *vertex_markers;
-  util::Array1D<SizeT, unsigned char> *visited_masks;
-  util::Array1D<SizeT, LabelT> *labels;
-  util::CudaProperties *cuda_props;
+        mgpu::standard_context_t* context = nullptr;
+        cudaStream_t stream;
 
-  // VertexT *d_backward_index_queue;
-  // bool    *d_backward_frontier_map_in;
-  // bool    *d_backward_frontier_map_out;
-  // SizeT         max_in;
-  // SizeT         max_out;
-  cudaStream_t stream;
+        bool get_output_length;
+        bool reduce_reset;
+        std::string advance_mode;
+        std::string filter_mode;
+        LabelT label;
+        int max_grid_size;
 
-  // TODO: Attach stream to the context
-  mgpu::standard_context_t context;
+        // Set print_prop to false to hide output
+        OprtrParameters(cudaStream_t stream = 0) { Init(); }
 
-  bool get_output_length;
-  bool reduce_reset;
-  std::string advance_mode;
-  std::string filter_mode;
-  // bool          filtering_flag;
-  // bool          skip_marking;
-  LabelT label;
-  int max_grid_size;
+        ~OprtrParameters() { Release(); }
 
-  // Set print_prop to false to hide output
-  OprtrParameters() : context(false)
-    { Init(); }
+        cudaError_t Init(cudaStream_t stream = 0) {
+            this->stream = stream;
 
-  ~OprtrParameters() { Init(); }
+            if (context != nullptr) {
+                Release();
+            }
+            context = new mgpu::standard_context_t(false, stream);
+            if (context == nullptr) {
+                return cudaErrorMemoryAllocation;
+            }
 
-  cudaError_t Init() {
-    // enactor_stats      = NULL;
-    frontier = NULL;
-    values_in = NULL;
-    values_out = NULL;
-    // output_offsets     = NULL;
-    reduce_values_temp = NULL;
-    reduce_values_temp2 = NULL;
-    reduce_values_out = NULL;
-    vertex_markers = NULL;
-    visited_masks = NULL;
-    labels = NULL;
-    cuda_props = NULL;
-    // max_in             = 0;
-    // max_out            = 0;
-    // context            = NULL;
-    stream = 0;
-    get_output_length = true;
-    reduce_reset = true;
-    advance_mode = "";
-    filter_mode = "";
-    max_grid_size = 0;
-    return cudaSuccess;
-  }
-};
+            frontier = NULL;
+            values_in = NULL;
+            values_out = NULL;
+            reduce_values_temp = NULL;
+            reduce_values_temp2 = NULL;
+            reduce_values_out = NULL;
+            vertex_markers = NULL;
+            visited_masks = NULL;
+            labels = NULL;
+            cuda_props = NULL;
+            get_output_length = true;
+            reduce_reset = true;
+            advance_mode = "";
+            filter_mode = "";
+            max_grid_size = 0;
+            return cudaSuccess;
+        }
 
+        cudaError_t Release() {
+            delete context;
+            context = nullptr;
+
+            return cudaSuccess;
+        }
+    };
 }  // namespace oprtr
 }  // namespace gunrock
 

--- a/gunrock/util/scan_device.cuh
+++ b/gunrock/util/scan_device.cuh
@@ -61,12 +61,13 @@ template <typename InputT, typename OutputT,
           typename ReduceT, typename SizeT>
 cudaError_t Scan(util::Array1D<SizeT, InputT> &d_in, SizeT num_items,
                  util::Array1D<SizeT, OutputT> &d_out,
-                 ReduceT *r, mgpu::context_t &context,
+                 ReduceT *r, mgpu::context_t *context,
                  bool debug_synchronous = false) {
 
+  if (context == nullptr) {
+      return cudaErrorInvalidValue;
+  }
   cudaError_t retval = cudaSuccess; 
-//   cudaStream_t stream = 0;
-//   mgpu::standard_context_t context(false, stream);
 
   // TODO: Experiment with these values and choose the best ones. We
   // could even choose to make them a parameter of util::Scan and choose
@@ -82,7 +83,7 @@ cudaError_t Scan(util::Array1D<SizeT, InputT> &d_in, SizeT num_items,
   mgpu::scan<mgpu::scan_type_inc, launch_t>(d_in.GetPointer(util::DEVICE), num_items,
                                   d_out.GetPointer(util::DEVICE),
                                   mgpu::plus_t<InputT>(), r,
-                                  context);
+                                  *context);
 
   if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
 

--- a/gunrock/util/sorted_search.cuh
+++ b/gunrock/util/sorted_search.cuh
@@ -33,9 +33,12 @@ template <typename A, typename B, typename C, typename SizeT>
 cudaError_t SortedSearch(util::Array1D<SizeT, A> &needles, SizeT num_needles,
                         util::Array1D<SizeT, B> &haystack, SizeT num_haystack,
                         util::Array1D<SizeT, C> &indices,
-                        mgpu::context_t &context,
+                        mgpu::context_t *context,
                         bool debug_synchronous = false) {
 
+  if (context == nullptr) {
+      return cudaErrorInvalidValue;
+  }
   cudaError_t retval = cudaSuccess;
 
   // TODO: Experiment with these values and choose the best ones. We
@@ -53,7 +56,7 @@ cudaError_t SortedSearch(util::Array1D<SizeT, A> &needles, SizeT num_needles,
   mgpu::sorted_search<mgpu::bounds_lower, launch_t>(needles.GetPointer(util::DEVICE), num_needles,
                                                     haystack.GetPointer(util::DEVICE), num_haystack,
                                                     indices.GetPointer(util::DEVICE), mgpu::less_t<A>(),
-                                                    context);
+                                                    *context);
 
   if (debug_synchronous) GUARD_CU2(cudaDeviceSynchronize(), "cudaDeviceSynchronize failed");
 


### PR DESCRIPTION
After updating moderngpu from 1.0 -> 2.0 we forgot to make sure that the
mgpu calls were on the same stream as our other kernels. Operators using
mgpu's SortedSearch and Scan functions expected them to be complete
before the next kernel call, but since the mgpu context was on the
default stream it executed in parallel with the other kernels. This
caused the output_offsets array used in the following kernel to be incorrect,
and out of bounds memory accesses would occur.

This fix ensures that the mgpu::standard_context_t is setup to use the
same stream as the other kernels. To do so, we keep a context pointer,
allocate it on the heap when the operator parameters are intialized, and
free it when they are released.