### PR TITLE
SetDevice after spawning OpenMP threads

### DIFF
--- a/gunrock/app/test_base.cuh
+++ b/gunrock/app/test_base.cuh
@@ -709,6 +709,11 @@ struct Switch_VertexT<OpT, FLAG, VERTEXT_U32B | VERTEXT_U64B> {
 template <SwitchFlag FLAG, typename OpT>
 cudaError_t Switch_Types(util::Parameters &parameters, OpT op) {
   cudaError_t retval = cudaSuccess;
+
+  // Ensure we set the proper device before any other operations take place
+  auto gpu_idx = parameters.Get<std::vector<int>>("device");
+  if (gpu_idx.size() > 0) GUARD_CU(util::SetDevice(gpu_idx[0]));
+
   retval = Switch_VertexT<OpT, FLAG, FLAG & VERTEXT_BASE>::Act(parameters, op);
   return retval;
 }

--- a/gunrock/util/test_utils.cu
+++ b/gunrock/util/test_utils.cu
@@ -82,5 +82,10 @@ cudaError_t SetDevice(int dev) {
                        __LINE__);
 }
 
+cudaError_t GetDevice(int* dev) {
+  return util::GRError(cudaGetDevice(dev), "cudaGetDevice failed.", __FILE__,
+                      __LINE__);
+}
+
 }  // namespace util
 }  // namespace gunrock

--- a/gunrock/util/test_utils.h
+++ b/gunrock/util/test_utils.h
@@ -180,6 +180,7 @@ class CommandLineArgs {
 
 void DeviceInit(CommandLineArgs &args);
 cudaError_t SetDevice(int dev);
+cudaError_t GetDevice(int* dev);
 
 template <typename T>
 void CommandLineArgs::GetCmdLineArgument(const char *arg_name, T &val) {


### PR DESCRIPTION
By default all newly created threads are associated with the default
device (see reference). This means newly spawned threads must switch
their device if they are not supposed to use the default device.
When RemoveEdges did not set the device as it should, the graph was
allocated to the wrong GPU. Then subsequent kernels would not find it on
the device they ran on.

In the future I recommend attaching some information about the allocated
device to the underlying Array1D. Without this information, it's
impossible to tell whether a given device pointer is invalid or valid on
a different GPU.