### PR TITLE
Fix Release issue for multiple parameter switches

### DIFF
--- a/gunrock/app/problem_base.cuh
+++ b/gunrock/app/problem_base.cuh
@@ -176,18 +176,24 @@ struct ProblemBase {
   cudaError_t Release(util::Location target = util::LOCATION_ALL) {
     cudaError_t retval = cudaSuccess;
     // Cleanup graph slices on the heap
-    if (sub_graphs.GetPointer(util::HOST) != NULL) {
-      // We should have the same number of sub_graphs as GPUs
-      assert(num_gpus == sub_graphs.GetSize());
 
-      for (int i = 0; i < num_gpus; ++i) {
-        if (num_gpus != 1 && (target & util::DEVICE))
-        {
-          GUARD_CU(util::SetDevice(gpu_idx[i]));
+    // When num_gpus > 1, we have allocated a partition of graphs and must
+    // call Release on each one. In the single gpu case, we never paritioned
+    // our graph and shouldn't call Release
+    if (num_gpus > 1) {
+      if (sub_graphs.GetPointer(util::HOST) != NULL) {
+        // We should have the same number of sub_graphs as GPUs
+        assert(num_gpus == sub_graphs.GetSize());
+
+        for (int i = 0; i < num_gpus; ++i) {
+          if (num_gpus != 1 && (target & util::DEVICE))
+          {
+            GUARD_CU(util::SetDevice(gpu_idx[i]));
+          }
+          GUARD_CU(sub_graphs[i].Release(target));
         }
-        GUARD_CU(sub_graphs[i].Release(target));
+        GUARD_CU(sub_graphs.Release(target));
       }
-      GUARD_CU(sub_graphs.Release(target));
     }
 
     if (target & util::HOST) {
@@ -210,6 +216,8 @@ struct ProblemBase {
     cudaError_t retval = cudaSuccess;
     this->org_graph = &graph;
 
+    // When num_gpus > 1, we allocate a partition of graphs. In the single
+    // gpu case, we set sub_graphs to the graph's pointer
     if (num_gpus == 1)
       sub_graphs.SetPointer(&graph, 1, util::HOST);
     else {


### PR DESCRIPTION
I added single graph release to the problem_base.cuh code a bit back.
But that was a mistake. When num_gpus == 1, we use SetPointer to create
our sub_graphs array, rather than allocating individual components. So
when num_gpus == 1, no Release should be happening in the problem. This
caused the graph to be invalid during subsequent runs when multiple
parameters were set.