### PR TITLE
Fix SM mappings bug

### DIFF
--- a/gunrock/app/sm/sm_app.cu
+++ b/gunrock/app/sm/sm_app.cu
@@ -63,7 +63,7 @@ double sm(
     const int                *query_col_indices,
     const int                 num_runs,
     unsigned long            *subgraphs,
-    unsigned long            *list_subgraphs,
+    unsigned long            **list_subgraphs,
     gunrock::util::Location   allocated_on = gunrock::util::HOST)
 {
     return sm_template(num_nodes, num_edges, row_offsets, col_indices,

--- a/gunrock/app/sm/sm_app.cuh
+++ b/gunrock/app/sm/sm_app.cuh
@@ -61,7 +61,7 @@ cudaError_t RunTests(util::Parameters &parameters, GraphT &data_graph,
   util::Info info("SM", parameters, data_graph);  // initialize Info structure
 
   unsigned long *count_subgraphs = new unsigned long[1];
-  unsigned long *list_subgraphs;
+  unsigned long **list_subgraphs = new unsigned long*[1];
 
   ProblemT problem(parameters);
   EnactorT enactor;
@@ -146,7 +146,7 @@ cudaError_t RunTests(util::Parameters &parameters, GraphT &data_graph,
 template <typename GraphT, typename ValueT = typename GraphT::ValueT>
 double gunrock_sm(gunrock::util::Parameters &parameters, GraphT &data_graph,
                   GraphT &query_graph, unsigned long *subgraphs,
-                  unsigned long *list_subgraphs,
+                  unsigned long **list_subgraphs,
                   gunrock::util::Location allocated_on = gunrock::util::HOST) {
   typedef typename GraphT::VertexT VertexT;
   typedef gunrock::app::sm::Problem<GraphT> ProblemT;
@@ -202,7 +202,7 @@ double sm_template(const SizeT num_nodes, const SizeT num_edges,
                    const SizeT num_query_nodes, const SizeT num_query_edges,
                    const SizeT *query_row_offsets,
                    const VertexT *query_col_indices, const int num_runs,
-                   unsigned long *subgraphs, unsigned long *list_subgraphs,
+                   unsigned long *subgraphs, unsigned long **list_subgraphs,
                    gunrock::util::Location allocated_on = gunrock::util::HOST) {
   typedef typename gunrock::app::TestGraph<VertexT, SizeT, VertexT,
                                            gunrock::graph::HAS_CSR>

--- a/gunrock/app/sm/sm_problem.cuh
+++ b/gunrock/app/sm/sm_problem.cuh
@@ -413,7 +413,7 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
    * \return     cudaError_t Error message(s), if any
    */
   cudaError_t Extract(unsigned long *count_subgraphs,
-                      unsigned long *list_subgraphs,
+                      unsigned long **list_subgraphs,
                       util::Location target = util::DEVICE,
                       util::Location device = util::HOST) {
     cudaError_t retval = cudaSuccess;
@@ -454,17 +454,17 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
             unique(combinations.begin(), combinations.end());
         combinations.resize(distance(combinations.begin(), itr));
         count_subgraphs[0] = combinations.size();
-        list_subgraphs = new unsigned long[combinations.size() * nodes_query];
+        *list_subgraphs = new unsigned long[combinations.size() * nodes_query];
         size_t iter = 0;
         for (size_t i = 0; i < combinations.size(); ++i) {
           for (size_t j = 0; j < nodes_query; ++j) {
-            list_subgraphs[iter++] = combinations[i][j];
+            (*list_subgraphs)[iter++] = combinations[i][j];
           }
         }
       } else { // returning results will be stored on the GPU
         if (target == util::DEVICE) {
           count_subgraphs = data_slice.temp_count.GetPointer(util::DEVICE);
-          list_subgraphs = data_slice.results.GetPointer(util::DEVICE);
+          *list_subgraphs = data_slice.results.GetPointer(util::DEVICE);
         }
       }
     } else {  // num_gpus != 1

--- a/gunrock/gunrock.h
+++ b/gunrock/gunrock.h
@@ -413,7 +413,7 @@ double sm(
     const int           *query_col_indices,
     const int            num_runs,
     unsigned long       *subgraphs,
-    unsigned long       *list_subgraphs,
+    unsigned long       **list_subgraphs,
     unsigned int         device
 );
 

--- a/unittests/test_lib_sm.h
+++ b/unittests/test_lib_sm.h
@@ -13,7 +13,7 @@ TEST(sharedlibrary, sm) {
   int query_col_indices[6] = {1, 2, 0, 2, 0, 1};
 
   unsigned long *sm_counts = new unsigned long[1];
-  unsigned long *list_sm;
+  unsigned long **list_sm = new unsigned long*[1];
   unsigned int device = 0x01;  // CPU
 
   double elapsed = sm(num_data_nodes, num_data_edges, data_row_offsets,
@@ -21,11 +21,19 @@ TEST(sharedlibrary, sm) {
                       query_row_offsets, query_col_indices, 1, sm_counts,
                       list_sm, device);
 
-  double counts[1] = {1};
 
-  EXPECT_EQ(sm_counts[0], counts[0])
+  EXPECT_EQ(sm_counts[0], 1)
       << "Number of matched subgraphs are different";
+
+  unsigned long expected[] = {0, 1, 3};
+  for (int i=0; i < 3; i++) {
+    EXPECT_EQ((*list_sm)[i], expected[i]);
+  }
 
   delete[] sm_counts;
   sm_counts = NULL;
+
+  delete[] (*list_sm);
+  delete[] list_sm;
+  list_sm = NULL;
 }


### PR DESCRIPTION
Leyuan extended Gunrock's SM application to return mappings between query graph and the base graph. However the pointer to the allocated memory that contained the mappings was not passed to the C API properly.

This pull request fixes the issue. I included a small test case in `test_lib_sm.h`.