### PR TITLE
Fix RAW and WAR hazards found using cuda-memcheck

### DIFF
--- a/gunrock/util/scan/cooperative_scan.cuh
+++ b/gunrock/util/scan/cooperative_scan.cuh
@@ -287,6 +287,8 @@ struct CooperativeGridScan<RakingDetails, NullType> {
       T exclusive_partial = WarpScan<RakingDetails::LOG_RAKING_THREADS>::Invoke(
           inclusive_partial, warpscan_total, raking_details.warpscan, scan_op);
 
+      __syncthreads();
+
       // Atomic-increment the global counter with the total allocation
       T reservation_offset;
       if (threadIdx.x == 0) {
@@ -294,6 +296,8 @@ struct CooperativeGridScan<RakingDetails, NullType> {
             util::AtomicInt<T>::Add(d_enqueue_counter, warpscan_total);
         raking_details.warpscan[1][0] = reservation_offset;
       }
+
+      __syncthreads();
 
       // Seed exclusive partial with queue reservation offset
       reservation_offset = raking_details.warpscan[1][0];

--- a/gunrock/util/scan/warp_scan.cuh
+++ b/gunrock/util/scan/warp_scan.cuh
@@ -50,11 +50,11 @@ struct WarpScan {
            ReductionOp scan_op, int warpscan_tid) {
       warpscan[1][warpscan_tid] = exclusive_partial;
 
-      if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+      __syncthreads();
 
       T offset_partial = warpscan[1][warpscan_tid - OFFSET_LEFT];
 
-      if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+      __syncthreads();
 
       T inclusive_partial = scan_op(offset_partial, exclusive_partial);
 
@@ -150,7 +150,7 @@ struct WarpScan {
     // inclusive partial
     warpscan[1][warpscan_tid] = inclusive_partial;
 
-    if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+    __syncthreads();
 
     // Get total
     total_reduction = warpscan[1][NUM_ELEMENTS - 1];


### PR DESCRIPTION
`__syncthreads` was used to fix the hazards, but it might be unnecessary
to go that far.

Do you know more about these scan functions @neoblizz? Does CUB have this same function? Should we just use that? 