### PR TITLE
Fix graph memory allocation and undirected insertion batches

### DIFF
--- a/examples/dynamic_graph/test_dynamic_graph.cu
+++ b/examples/dynamic_graph/test_dynamic_graph.cu
@@ -97,17 +97,18 @@ struct main_struct {
       result_dyn_graph.dynamicGraph.InitHashTables(
           nodes, load_factor,
           input_graph_csr.row_offsets.GetPointer(util::HOST));
-      result_dyn_graph.is_directed = false;
+      result_dyn_graph.is_directed = true;
       result_dyn_graph.nodes = nodes;
       result_dyn_graph.edges = edges;
-
+      bool directed_edges = false;  // Input is from Market loader which will
+                                    // always double the edges
       util::PrintMsg("__________________________", !quiet);
 
       gunrock::util::GpuTimer gpu_timer;
       gpu_timer.Start();
       result_dyn_graph.InsertEdgesBatch(input_graph_coo.edge_pairs,
                                         input_graph_coo.edge_values, edges,
-                                        util::DEVICE);
+                                        directed_edges, util::DEVICE);
       gpu_timer.Stop();
       info.CollectSingleRun(gpu_timer.ElapsedMillis());
 

--- a/examples/dynamic_graph/test_dynamic_graph.cu
+++ b/examples/dynamic_graph/test_dynamic_graph.cu
@@ -117,8 +117,8 @@ struct main_struct {
               " elapsed: " + std::to_string(gpu_timer.ElapsedMillis()) + " ms.",
           !quiet);
 
-      if (validation == "each" ||
-          validation == "last" && run_num == num_runs - 1) {
+      if (!quick && (validation == "each" ||
+          validation == "last" && run_num == num_runs - 1)) {
         bool failed =
             CompareWeightedDynCSR(input_graph_csr, result_dyn_graph, quiet);
         if (failed) {

--- a/gunrock/graph/dynamic_graph/dynamic_graph_unweighted.cuh
+++ b/gunrock/graph/dynamic_graph/dynamic_graph_unweighted.cuh
@@ -38,11 +38,13 @@ struct Dyn<VertexT, SizeT, ValueT, FLAG, cudaHostRegisterFlag, true, false>
    *
    * @param[in] edges Pointer to pairs of edges
    * @param[in] batch_size Size of the inserted batch
+   * @param[in] batch_directed Batch contains directed edges (i.e, false means
+   * double the batch edges)
    * @param[in] target Location of the edges data
    */
   template <typename PairT>
   cudaError_t InsertEdgesBatch(util::Array1D<SizeT, PairT> edges,
-                               SizeT batchSize,
+                               SizeT batchSize, bool batch_directed = true,
                                util::Location target = util::DEVICE) {
     return cudaSuccess;
   }
@@ -119,7 +121,7 @@ template <typename VertexT, typename SizeT, typename ValueT, GraphFlag FLAG,
 struct Dyn<VertexT, SizeT, ValueT, FLAG, cudaHostRegisterFlag, false, false> {
   template <typename PairT>
   cudaError_t InsertEdgesBatch(util::Array1D<SizeT, PairT> edges,
-                               SizeT batchSize,
+                               SizeT batchSize, bool batch_directed = true,
                                util::Location target = util::DEVICE) {
     return cudaSuccess;
   }

--- a/gunrock/graph/dynamic_graph/dynamic_graph_weighted.cuh
+++ b/gunrock/graph/dynamic_graph/dynamic_graph_weighted.cuh
@@ -35,16 +35,16 @@ struct Dyn<VertexT, SizeT, ValueT, FLAG, cudaHostRegisterFlag, true, true>
   template <typename PairT>
   cudaError_t InsertEdgesBatch(util::Array1D<SizeT, PairT> &edges,
                                util::Array1D<SizeT, ValueT> &vals,
-                               SizeT batchSize,
+                               SizeT batchSize, bool batch_directed = true,
                                util::Location target = util::DEVICE) {
     if (target != util::DEVICE) {
       edges.Move(util::HOST, util::DEVICE);
       vals.Move(util::HOST, util::DEVICE);
     }
 
-    this->dynamicGraph.InsertEdgesBatch(edges.GetPointer(util::DEVICE),
-                                        vals.GetPointer(util::DEVICE),
-                                        batchSize, !this->is_directed);
+    this->dynamicGraph.InsertEdgesBatch(
+        edges.GetPointer(util::DEVICE), vals.GetPointer(util::DEVICE),
+        batchSize, (!this->is_directed) && batch_directed);
 
     if (target != util::DEVICE) {
       edges.Release(util::DEVICE);
@@ -105,7 +105,7 @@ struct Dyn<VertexT, SizeT, ValueT, FLAG, cudaHostRegisterFlag, false, true> {
   template <typename PairT>
   cudaError_t InsertEdgesBatch(util::Array1D<SizeT, PairT> src,
                                util::Array1D<SizeT, ValueT> vals,
-                               SizeT batchSize,
+                               SizeT batchSize, bool batch_directed = true,
                                util::Location target = util::DEVICE) {
     return cudaSuccess;
   }

--- a/unittests/test_dynamic_graph.h
+++ b/unittests/test_dynamic_graph.h
@@ -122,8 +122,10 @@ TEST(dynamicGraph, insertUndirectedWeighted) {
   edges_batch_values.Move(util::HOST, util::DEVICE);
 
   // insert the edges batch
+  bool directed_batch = true;
   result_dynamic_graph.InsertEdgesBatch(edges_batch, edges_batch_values,
-                                        batch_size, util::DEVICE);
+                                        batch_size, directed_batch,
+                                        util::DEVICE);
 
   // Apply batch to host graph & generate values as well
   SizeT new_edges_count = edges;
@@ -199,8 +201,10 @@ TEST(dynamicGraph, insertDirectedWeighted) {
   edges_batch_values.Move(util::HOST, util::DEVICE);
 
   // insert the edges batch
+  bool directed_batch = true;
   result_dynamic_graph.InsertEdgesBatch(edges_batch, edges_batch_values,
-                                        batch_size, util::DEVICE);
+                                        batch_size, directed_batch,
+                                        util::DEVICE);
 
   // Apply batch to host graph & generate values as well
   SizeT new_edges_count = edges;

--- a/unittests/test_graph_iterator.h
+++ b/unittests/test_graph_iterator.h
@@ -107,8 +107,9 @@ TEST(dynamicGraphIterator, SingleBucketMultipleChains) {
   edges_batch_values.Move(util::HOST, util::DEVICE);
 
   // insert the edges batch
+  bool directed_batch = true;
   ref_dynamic_graph.InsertEdgesBatch(edges_batch, edges_batch_values,
-                                     batch_size, util::DEVICE);
+                                     batch_size, directed_batch, util::DEVICE);
 
   // call advance
   std::vector<VertexT> result_frontier;
@@ -191,8 +192,9 @@ TEST(dynamicGraphIterator, MultipleBucketMultipleChains) {
   edges_batch_values.Move(util::HOST, util::DEVICE);
 
   // insert the edges batch
+  bool directed_batch = true;
   ref_dynamic_graph.InsertEdgesBatch(edges_batch, edges_batch_values,
-                                     batch_size, util::DEVICE);
+                                     batch_size, directed_batch, util::DEVICE);
 
   // call advance
   std::vector<VertexT> result_frontier;


### PR DESCRIPTION
- Moved the hash table base slabs allocation to the allocate function (where we know how many base slabs we need)
- Added an option for batched edge insertion functions to avoid doubling edges when the batch is already undirected