### PR TITLE
Bring in rw (random walk) multi-gpu work in progress

### DIFF
--- a/examples/rw/Makefile
+++ b/examples/rw/Makefile
@@ -20,6 +20,10 @@ $(EXEC) : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
 	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O3
 
+debug : test_$(ALGO).cu $(DEPS)
+	mkdir -p bin
+	$(NVCC) -w $(DEFINES) $(SM_TARGETS) -o $(EXEC) test_$(ALGO).cu $(EXTRA_SOURCE) $(NVCCFLAGS) $(ARCH) $(INC) -O0 -g -G
+
 a : test_$(ALGO).cu $(DEPS)
 	mkdir -p bin
 	rm -f $(EXEC)

--- a/examples/rw/test_rw.cu
+++ b/examples/rw/test_rw.cu
@@ -59,7 +59,7 @@ struct main_struct {
     }
 
     typedef typename app::TestGraph<VertexT, SizeT, ValueT,
-                                    graph::HAS_NODE_VALUES | graph::HAS_CSR>
+                                    graph::HAS_NODE_VALUES | graph::HAS_CSR | graph::GRAPH_UNIFIED>
         GraphT;
     typedef typename GraphT::CsrT CsrT;
 

--- a/gunrock/app/rw/rw_app.cu
+++ b/gunrock/app/rw/rw_app.cu
@@ -81,7 +81,7 @@ cudaError_t RunTests(util::Parameters &parameters, GraphT &graph,
   typedef typename GraphT::ValueT ValueT;
   typedef typename GraphT::SizeT SizeT;
   typedef Problem<GraphT> ProblemT;
-  typedef Enactor<ProblemT> EnactorT;
+  typedef Enactor<ProblemT, util::UNIFIED> EnactorT;
 
   // CLI parameters
   bool quiet_mode = parameters.Get<bool>("quiet");

--- a/gunrock/app/rw/rw_enactor.cuh
+++ b/gunrock/app/rw/rw_enactor.cuh
@@ -88,6 +88,8 @@ struct RWIterationLoop : public IterationLoopBase<EnactorT, Use_FullQ | Push> {
     auto &neighbors_seen = data_slice.neighbors_seen;
     auto &steps_taken = data_slice.steps_taken;
 
+    util::Location target = util::DEVICE;
+
     if (walk_mode == 0) {  // uniform random walk
 
       auto uniform_rw_op =
@@ -128,8 +130,14 @@ struct RWIterationLoop : public IterationLoopBase<EnactorT, Use_FullQ | Push> {
       curandSetStream(gen, oprtr_parameters.stream);
       curandGenerateUniform(gen, rand.GetPointer(util::DEVICE),
                             graph.nodes * walks_per_node);
-      GUARD_CU(frontier.V_Q()->ForAll(uniform_rw_op, frontier.queue_length,
-                                      util::DEVICE, oprtr_parameters.stream));
+
+      GUARD_CU(
+        oprtr::mgpu_ForAll(frontier.V_Q()->GetPointer(target),
+                           uniform_rw_op,
+                           frontier.queue_length,
+                           target,
+                           oprtr_parameters.stream)
+      );
 
     } else if (walk_mode ==
                1) {  // greedy: walk to neighbor w/ maximum node value
@@ -176,8 +184,16 @@ struct RWIterationLoop : public IterationLoopBase<EnactorT, Use_FullQ | Push> {
             }
           };
 
-      GUARD_CU(frontier.V_Q()->ForAll(greedy_rw_op, frontier.queue_length,
-                                      util::DEVICE, oprtr_parameters.stream));
+      //GUARD_CU(frontier.V_Q()->ForAll(greedy_rw_op, frontier.queue_length,
+      //                                util::DEVICE, oprtr_parameters.stream));
+      GUARD_CU(
+        oprtr::mgpu_ForAll(frontier.V_Q()->GetPointer(target),
+                           greedy_rw_op,
+                           frontier.queue_length,
+                           target,
+                           oprtr_parameters.stream)
+      );
+
 
     } else if (walk_mode == 2) {
       curandGenerateUniform(gen, rand.GetPointer(util::DEVICE),
@@ -233,9 +249,13 @@ struct RWIterationLoop : public IterationLoopBase<EnactorT, Use_FullQ | Push> {
             }
           };
 
-      GUARD_CU(frontier.V_Q()->ForAll(stochastic_greedy_rw_op,
-                                      frontier.queue_length, util::DEVICE,
-                                      oprtr_parameters.stream));
+      GUARD_CU(
+        oprtr::mgpu_ForAll(frontier.V_Q()->GetPointer(target),
+                           stochastic_greedy_rw_op,
+                           frontier.queue_length,
+                           target,
+                           oprtr_parameters.stream)
+      );
 
     } else {
       printf("ERROR: unknown walk_mode=%d\n", walk_mode);

--- a/gunrock/app/rw/rw_problem.cuh
+++ b/gunrock/app/rw/rw_problem.cuh
@@ -51,6 +51,9 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
   typedef ProblemBase<GraphT, FLAG> BaseProblem;
   typedef DataSliceBase<GraphT, FLAG> BaseDataSlice;
 
+  // Use CUDA manage memory
+  static const util::ArrayFlag ARRAY_FLAG = util::UNIFIED;
+
   // ----------------------------------------------------------------
   // Dataslice structure
 
@@ -59,10 +62,10 @@ struct Problem : ProblemBase<_GraphT, _FLAG> {
    */
   struct DataSlice : BaseDataSlice {
     // problem specific storage arrays:
-    util::Array1D<SizeT, VertexT> walks;
-    util::Array1D<SizeT, float> rand;
-    util::Array1D<SizeT, uint64_t> neighbors_seen;
-    util::Array1D<SizeT, uint64_t> steps_taken;
+    util::Array1D<SizeT, VertexT,   ARRAY_FLAG> walks;
+    util::Array1D<SizeT, float,     ARRAY_FLAG> rand;
+    util::Array1D<SizeT, uint64_t,  ARRAY_FLAG> neighbors_seen;
+    util::Array1D<SizeT, uint64_t,  ARRAY_FLAG> steps_taken;
     int walk_length;
     int walks_per_node;
     int walk_mode;

--- a/gunrock/oprtr/1D_oprtr/for_all.cuh
+++ b/gunrock/oprtr/1D_oprtr/for_all.cuh
@@ -243,8 +243,9 @@ cudaError_t mgpu_ForAll(T *elements, ApplyLambda apply, SizeT length,
   int num_gpus = 1;
   GUARD_CU(cudaGetDeviceCount(&num_gpus));
 
-
-  u_int num_elements_per_gpu = length / num_gpus;
+  // Use cieling to make sure we don't miss any values when
+  // finding the number of elements to assign each GPU.
+  u_int num_elements_per_gpu = (length + num_gpus - 1) / num_gpus;
 
   // prepare a cuda stream (non-blocking) and 
   // events for each gpu
@@ -259,10 +260,6 @@ cudaError_t mgpu_ForAll(T *elements, ApplyLambda apply, SizeT length,
     info.data_length = num_elements_per_gpu;
     gpu_infos.push_back(info);
   }
-
-  // give the last gpu any left over elements
-  gpu_infos.back().data_length += length % num_gpus;
-
 
   // launch kernel for each gpu
   for(u_int i = 0; i < gpu_infos.size(); i++) {


### PR DESCRIPTION
Swap out single gpu for_all operations with multi-gpu equivalents. While the various walk modes run to completion, the results are incorrect (lots of -1s in the output) and further debugging is necessary.