### PR TITLE
Fix louvain to build with multi-GPU

### DIFF
--- a/examples/louvain/Makefile
+++ b/examples/louvain/Makefile
@@ -11,8 +11,8 @@
 
 include ../BaseMakefile.mk
 ALGO = louvain
-EXEC = bin/$(ALGO)_main_$(NVCC_VERSION)_$(ARCH_SUFFIX)
-SRC = $(ALGO)_main.cu
+EXEC = bin/test_$(ALGO)_$(NVCC_VERSION)_$(ARCH_SUFFIX)
+SRC = test_$(ALGO).cu
 
 test: $(EXEC)
 

--- a/gunrock/app/louvain/louvain_enactor.cuh
+++ b/gunrock/app/louvain/louvain_enactor.cuh
@@ -240,11 +240,9 @@ struct LouvainIterationLoop
             },
             graph.edges, target, stream));
 
-        /* SKIP NEEDS REWRITTEN FIXME PLS PLS PLS FIXME DONT IGNORE
         GUARD_CU(util::cubSortPairs(cub_temp_space, edge_pairs0, edge_pairs1,
                                     weights, edge_weights1, graph.edges, 0,
                                     sizeof(EdgePairT) * 8, stream));
-        */
 
         GUARD_CU(seg_offsets0.Set(0, graph.edges + 1, target, stream));
 
@@ -278,12 +276,10 @@ struct LouvainIterationLoop
             },
             graph.edges, target, stream));
 
-        /* FIXME PLS PLS
         GUARD_CU(util::cubSegmentedSortPairs(
             cub_temp_space, edge_comms0, edge_comms1, edge_weights0,
             edge_weights1, graph.edges, graph.nodes, graph.CsrT::row_offsets, 0,
             std::ceil(std::log2(graph.nodes)), stream));
-        */
 
         GUARD_CU(seg_offsets0.Set(0, graph.edges + 1, target, stream));
 
@@ -294,7 +290,7 @@ struct LouvainIterationLoop
             },
             graph.nodes + 1, target, stream));
 
-        GUARD_CU(oprtr::mgpu_ForAll(mgpu_context, seg_offsets0.GetPointer(util::DEVICE), 
+        GUARD_CU(oprtr::mgpu_ForAll(mgpu_context, seg_offsets0.GetPointer(util::DEVICE),
             [edge_comms1] __host__ __device__(SizeT * offsets, const SizeT &e) {
               bool to_keep = false;
               if (offsets[e] == 1)
@@ -311,13 +307,11 @@ struct LouvainIterationLoop
       }
 
       // Filter in order
-      /* FIXME PLS
       GUARD_CU(util::cubSelectIf(
           cub_temp_space, seg_offsets0, seg_offsets1, num_neighbor_comms,
           graph.edges + 1,
           [] __host__ __device__(const SizeT &e) { return util::isValid(e); },
           stream));
-      */
 
       GUARD_CU2(cudaStreamSynchronize(stream), "cudaStreamSynchronize failed.");
 
@@ -333,7 +327,6 @@ struct LouvainIterationLoop
       //    graph.edges - num_neighbor_comms[0] - 1,
       //    target, stream));
 
-      /* FIXMEPLS
       GUARD_CU(util::SegmentedReduce(
           cub_temp_space, edge_weights1, edge_weights0, n_neighbor_comms,
           seg_offsets1,
@@ -341,7 +334,6 @@ struct LouvainIterationLoop
             return a + b;
           },
           (ValueT)0, stream));
-      */
 
       GUARD_CU(oprtr::mgpu_ForAll(mgpu_context, seg_offsets0.GetPointer(util::DEVICE),
           [seg_offsets1, n_neighbor_comms, graph] __host__ __device__(
@@ -498,14 +490,12 @@ struct LouvainIterationLoop
           },
           graph.nodes, target, stream));
 
-      /* FIXME PLS
       GUARD_CU(util::cubReduce(
           cub_temp_space, max_gains, iter_gain, graph.nodes,
           [] __host__ __device__(const ValueT &a, const ValueT &b) {
             return a + b;
           },
           (ValueT)0, stream));
-      */
 
       // GUARD_CU(iter_gain.ForEach(
       //    [] __host__ __device__ (const ValueT &gain)
@@ -570,7 +560,6 @@ struct LouvainIterationLoop
         },
         graph.nodes, target, stream));
 
-    /* FIXME PLS
     GUARD_CU(util::cubSelectIf(cub_temp_space, edge_comms0, edge_comms1,
                                num_new_comms, graph.nodes,
                                [] __host__ __device__(EdgePairT & comm) {
@@ -581,7 +570,6 @@ struct LouvainIterationLoop
                                  return (util::isValid(comm));
                                },
                                stream));
-    */
 
     GUARD_CU2(cudaStreamSynchronize(stream), "cudaStreamSynchronize failed");
 
@@ -640,11 +628,9 @@ struct LouvainIterationLoop
           return false;
         }));
 
-    /* FIXME PLS
     GUARD_CU(util::cubSortPairs(cub_temp_space, edge_pairs0, edge_pairs1,
                                 graph.CsrT::edge_values, edge_weights1,
                                 graph.edges, 0, sizeof(EdgePairT) * 8, stream));
-    */
 
     GUARD_CU(seg_offsets0.ForEach(
         [] __host__ __device__(SizeT & offset) {
@@ -664,14 +650,12 @@ struct LouvainIterationLoop
         },
         graph.edges + 1, target, stream));
 
-    /* FIXME PLS
     GUARD_CU(util::cubSelectIf(cub_temp_space, seg_offsets0, seg_offsets1,
                                num_new_edges, graph.edges + 1,
                                [] __host__ __device__(SizeT & offset) {
                                  return (util::isValid(offset));
                                },
                                stream));
-    */
 
     GUARD_CU2(cudaStreamSynchronize(stream), "cudaStreamSynchronize failed");
 
@@ -693,7 +677,6 @@ struct LouvainIterationLoop
     new_graph.CsrT::edges = n_new_edges;
     //}
 
-    /* FIXXME PLS
     GUARD_CU(util::SegmentedReduce(
         cub_temp_space, edge_weights1, new_graph.CsrT::edge_values, n_new_edges,
         seg_offsets1,
@@ -701,7 +684,6 @@ struct LouvainIterationLoop
           return a + b;
         },
         (ValueT)0, stream));
-    */
 
     GUARD_CU( oprtr::mgpu_ForAll(mgpu_context, new_graph.CsrT::column_indices.GetPointer(util::DEVICE),
         [edge_pairs1, seg_offsets1, n_new_comms] __host__ __device__(

--- a/gunrock/util/reduce_device.cuh
+++ b/gunrock/util/reduce_device.cuh
@@ -110,10 +110,11 @@ cudaError_t cubSegmentedReduce(util::Array1D<uint64_t, char> &cub_temp_space,
 }
 
 template <typename InputT, typename OutputT, typename SizeT,
-          typename ReductionOp>
-cudaError_t cubReduce(util::Array1D<uint64_t, char> &cub_temp_space,
-                      util::Array1D<SizeT, InputT> &keys_in,
-                      util::Array1D<SizeT, OutputT> &keys_out, SizeT num_keys,
+          typename ReductionOp, ArrayFlag FLAG>
+cudaError_t cubReduce(util::Array1D<uint64_t, char, FLAG> &cub_temp_space,
+                      util::Array1D<SizeT, InputT, FLAG> &keys_in,
+                      util::Array1D<SizeT, OutputT, FLAG> &keys_out,
+                      SizeT num_keys,
                       ReductionOp reduction_op, InputT initial_value,
                       cudaStream_t stream = 0, bool debug_synchronous = false) {
   cudaError_t retval = cudaSuccess;
@@ -140,12 +141,12 @@ cudaError_t cubReduce(util::Array1D<uint64_t, char> &cub_temp_space,
 }
 
 template <typename InputT, typename OutputT, typename SizeT,
-          typename ReductionOp>
-cudaError_t SegmentedReduce(util::Array1D<uint64_t, char> &temp_space,
-                            util::Array1D<SizeT, InputT> &keys_in,
-                            util::Array1D<SizeT, OutputT> &keys_out,
+          typename ReductionOp, ArrayFlag FLAG>
+cudaError_t SegmentedReduce(util::Array1D<uint64_t, char, FLAG> &temp_space,
+                            util::Array1D<SizeT, InputT, FLAG> &keys_in,
+                            util::Array1D<SizeT, OutputT, FLAG> &keys_out,
                             SizeT num_segments,
-                            util::Array1D<SizeT, SizeT> &segment_offsets,
+                            util::Array1D<SizeT, SizeT, FLAG> &segment_offsets,
                             ReductionOp reduction_op, OutputT initial_value,
                             cudaStream_t stream = 0,
                             bool debug_synchronous = false,

--- a/gunrock/util/select_device.cuh
+++ b/gunrock/util/select_device.cuh
@@ -183,11 +183,12 @@ cudaError_t CUBSelect(T *d_input, SizeT num_elements, T *d_output,
   return retval;
 }
 
-template <typename InputT, typename OutputT, typename SizeT, typename SelectOp>
-cudaError_t cubSelectIf(util::Array1D<uint64_t, char> &cub_temp_space,
-                        util::Array1D<SizeT, InputT> &keys_in,
-                        util::Array1D<SizeT, OutputT> &keys_out,
-                        util::Array1D<SizeT, SizeT> &num_selected,
+template <typename InputT, typename OutputT, typename SizeT, typename SelectOp,
+          ArrayFlag FLAG>
+cudaError_t cubSelectIf(util::Array1D<uint64_t, char, FLAG> &cub_temp_space,
+                        util::Array1D<SizeT, InputT, FLAG> &keys_in,
+                        util::Array1D<SizeT, OutputT, FLAG> &keys_out,
+                        util::Array1D<SizeT, SizeT, FLAG> &num_selected,
                         SizeT num_keys, SelectOp select_op,
                         cudaStream_t stream = 0,
                         bool debug_synchronous = false) {

--- a/gunrock/util/sort_device.cuh
+++ b/gunrock/util/sort_device.cuh
@@ -238,7 +238,7 @@ cudaError_t SegmentedSort(util::Array1D<SizeT, KeyT> &in,
     size_t request_bytes = 0;
 
     retval = cub::DeviceSegmentedRadixSort::SortKeys(NULL, request_bytes,
-            keys, num_items, num_segments, 
+            keys, num_items, num_segments,
             offsets.GetPointer(util::DEVICE),
             offsets.GetPointer(util::DEVICE) + 1,
             begin_bit, end_bit, stream, debug_synchronous);
@@ -246,11 +246,11 @@ cudaError_t SegmentedSort(util::Array1D<SizeT, KeyT> &in,
 
     retval = temp_space.EnsureSize_(request_bytes, util::DEVICE);
     if(retval) return retval;
-    
+
     retval = cub::DeviceSegmentedRadixSort::SortKeys(
-            temp_space.GetPointer(util::DEVICE), 
+            temp_space.GetPointer(util::DEVICE),
             request_bytes,
-            keys, num_items, num_segments, 
+            keys, num_items, num_segments,
             offsets.GetPointer(util::DEVICE),
             offsets.GetPointer(util::DEVICE) + 1,
             begin_bit, end_bit, stream, debug_synchronous);
@@ -376,13 +376,14 @@ cudaError_t cubSortPairsDescending(util::Array1D<uint64_t, char> &temp_space,
   return retval;
 }
 
-template <typename KeyT, typename ValueT, typename SizeT>
+template <typename KeyT, typename ValueT, typename SizeT, ArrayFlag FLAG>
 cudaError_t cubSegmentedSortPairs(
-    util::Array1D<uint64_t, char> &temp_space,
-    util::Array1D<SizeT, KeyT> &keys_in, util::Array1D<SizeT, KeyT> &keys_out,
-    util::Array1D<SizeT, ValueT> &values_in,
-    util::Array1D<SizeT, ValueT> &values_out, SizeT num_items,
-    SizeT num_segments, util::Array1D<SizeT, SizeT> &seg_offsets,
+    util::Array1D<uint64_t, char, FLAG> &temp_space,
+    util::Array1D<SizeT, KeyT, FLAG> &keys_in,
+    util::Array1D<SizeT, KeyT, FLAG> &keys_out,
+    util::Array1D<SizeT, ValueT, FLAG> &values_in,
+    util::Array1D<SizeT, ValueT, FLAG> &values_out, SizeT num_items,
+    SizeT num_segments, util::Array1D<SizeT, SizeT, FLAG> &seg_offsets,
     int begin_bit = 0, int end_bit = sizeof(KeyT) * 8, cudaStream_t stream = 0,
     bool debug_synchronous = false) {
   cudaError_t retval = cudaSuccess;


### PR DESCRIPTION
@crozhon had the right idea of adding a `ArrayType` template parameter to the templated functions with `util::Array1D` arguments. I extended that to all the other commented out calls that were having this issue.

The other problem I ran into was a linking issue with the [ceil_divide](https://github.com/gunrock/gunrock/compare/multigpu...cameronshinn:cameron-multigpu?expand=1#diff-4969aa931d4336e0aba64479d2dc37fb8abab5af5d2262672d45aa99804431bbL230-L231) function. It was being included in multiple places which made ld unsure of which one to use (despite them all being the same). Making the function `inline` fixes the problem.

https://stackoverflow.com/a/34618587

Note that these changes now make it that so louvain *builds*, but has not been run. I was getting errors trying to build in `examples/louvain/` but had it working with the normal CMake way.