### PR TITLE
Use external CUB API instead of internal ones

### DIFF
--- a/gunrock/util/reduce_device.cuh
+++ b/gunrock/util/reduce_device.cuh
@@ -81,29 +81,24 @@ cudaError_t cubSegmentedReduce(util::Array1D<uint64_t, char> &cub_temp_space,
   cudaError_t retval = cudaSuccess;
   size_t request_bytes = 0;
 
-  retval = cub::DispatchSegmentedReduce<
-      InputT *, OutputT *, SizeT *, SizeT,
-      ReductionOp>::Dispatch(NULL, request_bytes,
-                             keys_in.GetPointer(util::DEVICE),
-                             keys_out.GetPointer(util::DEVICE), num_segments,
-                             segment_offsets.GetPointer(util::DEVICE),
-                             segment_offsets.GetPointer(util::DEVICE) + 1,
-                             reduction_op, initial_value, stream,
-                             debug_synchronous);
+  retval = cub::DeviceSegmentedReduce::
+      Reduce(NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
+             keys_out.GetPointer(util::DEVICE), num_segments,
+             segment_offsets.GetPointer(util::DEVICE),
+             segment_offsets.GetPointer(util::DEVICE) + 1, reduction_op,
+             initial_value, stream, debug_synchronous);
   if (retval) return retval;
 
   retval = cub_temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
-  retval = cub::DispatchSegmentedReduce<
-      InputT *, OutputT *, SizeT *, SizeT,
-      ReductionOp>::Dispatch(cub_temp_space.GetPointer(util::DEVICE),
-                             request_bytes, keys_in.GetPointer(util::DEVICE),
-                             keys_out.GetPointer(util::DEVICE), num_segments,
-                             segment_offsets.GetPointer(util::DEVICE),
-                             segment_offsets.GetPointer(util::DEVICE) + 1,
-                             reduction_op, initial_value, stream,
-                             debug_synchronous);
+  retval = cub::DeviceSegmentedReduce::
+      Reduce(cub_temp_space.GetPointer(util::DEVICE), request_bytes,
+             keys_in.GetPointer(util::DEVICE),
+             keys_out.GetPointer(util::DEVICE), num_segments,
+             segment_offsets.GetPointer(util::DEVICE),
+             segment_offsets.GetPointer(util::DEVICE) + 1,
+             reduction_op, initial_value, stream, debug_synchronous);
   if (retval) return retval;
 
   return retval;
@@ -120,20 +115,21 @@ cudaError_t cubReduce(util::Array1D<uint64_t, char> &cub_temp_space,
   size_t request_bytes = 0;
 
   retval =
-      cub::DispatchReduce<InputT *, OutputT *, SizeT, ReductionOp>::Dispatch(
-          NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
-          keys_out.GetPointer(util::DEVICE), num_keys, reduction_op,
-          initial_value, stream, debug_synchronous);
+      cub::DeviceReduce::
+          Reduce(NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
+                 keys_out.GetPointer(util::DEVICE), num_keys, reduction_op,
+                 initial_value, stream, debug_synchronous);
   if (retval) return retval;
 
   retval = cub_temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
   retval =
-      cub::DispatchReduce<InputT *, OutputT *, SizeT, ReductionOp>::Dispatch(
-          cub_temp_space.GetPointer(util::DEVICE), request_bytes,
-          keys_in.GetPointer(util::DEVICE), keys_out.GetPointer(util::DEVICE),
-          num_keys, reduction_op, initial_value, stream, debug_synchronous);
+      cub::DeviceReduce::
+          Reduce(cub_temp_space.GetPointer(util::DEVICE), request_bytes,
+                 keys_in.GetPointer(util::DEVICE),
+                 keys_out.GetPointer(util::DEVICE), num_keys, reduction_op,
+                 initial_value, stream, debug_synchronous);
   if (retval) return retval;
 
   return retval;

--- a/gunrock/util/select_device.cuh
+++ b/gunrock/util/select_device.cuh
@@ -193,28 +193,22 @@ cudaError_t cubSelectIf(util::Array1D<uint64_t, char> &cub_temp_space,
                         bool debug_synchronous = false) {
   cudaError_t retval = cudaSuccess;
 
-  typedef cub::NullType *FlagIterator;
-  typedef cub::NullType EqualityOp;
-
   size_t request_bytes = 0;
-  retval = cub::DispatchSelectIf<
-      InputT *, FlagIterator, OutputT *, SizeT *, SelectOp, EqualityOp, SizeT,
-      false>::Dispatch(NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
-                       NULL, keys_out.GetPointer(util::DEVICE),
-                       num_selected.GetPointer(util::DEVICE), select_op,
-                       EqualityOp(), num_keys, stream, debug_synchronous);
+  retval = cub::DeviceSelect::
+      If(NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
+         keys_out.GetPointer(util::DEVICE),
+         num_selected.GetPointer(util::DEVICE), num_keys, select_op, stream,
+         debug_synchronous);
   if (retval) return retval;
 
   retval = cub_temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
-  retval = cub::DispatchSelectIf<
-      InputT *, FlagIterator, OutputT *, SizeT *, SelectOp, EqualityOp, SizeT,
-      false>::Dispatch(cub_temp_space.GetPointer(util::DEVICE), request_bytes,
-                       keys_in.GetPointer(util::DEVICE), NULL,
-                       keys_out.GetPointer(util::DEVICE),
-                       num_selected.GetPointer(util::DEVICE), select_op,
-                       EqualityOp(), num_keys, stream, debug_synchronous);
+  retval = cub::DeviceSelect::
+      If(cub_temp_space.GetPointer(util::DEVICE), request_bytes,
+         keys_in.GetPointer(util::DEVICE), keys_out.GetPointer(util::DEVICE),
+         num_selected.GetPointer(util::DEVICE), num_keys, select_op, stream,
+         debug_synchronous);
   if (retval) return retval;
 
   return retval;

--- a/gunrock/util/sort_device.cuh
+++ b/gunrock/util/sort_device.cuh
@@ -237,23 +237,21 @@ cudaError_t SegmentedSort(util::Array1D<SizeT, KeyT> &in,
     util::Array1D<uint64_t, char> temp_space;
     size_t request_bytes = 0;
 
-    retval = cub::DeviceSegmentedRadixSort::SortKeys(NULL, request_bytes,
-            keys, num_items, num_segments, 
-            offsets.GetPointer(util::DEVICE),
-            offsets.GetPointer(util::DEVICE) + 1,
-            begin_bit, end_bit, stream, debug_synchronous);
+    retval = cub::DeviceSegmentedRadixSort::
+        SortKeys(NULL, request_bytes, keys, num_items, num_segments,
+                 offsets.GetPointer(util::DEVICE),
+                 offsets.GetPointer(util::DEVICE) + 1, begin_bit, end_bit,
+                 stream, debug_synchronous);
     if(retval) return retval;
 
     retval = temp_space.EnsureSize_(request_bytes, util::DEVICE);
     if(retval) return retval;
     
-    retval = cub::DeviceSegmentedRadixSort::SortKeys(
-            temp_space.GetPointer(util::DEVICE), 
-            request_bytes,
-            keys, num_items, num_segments, 
-            offsets.GetPointer(util::DEVICE),
-            offsets.GetPointer(util::DEVICE) + 1,
-            begin_bit, end_bit, stream, debug_synchronous);
+    retval = cub::DeviceSegmentedRadixSort::
+        SortKeys(temp_space.GetPointer(util::DEVICE), request_bytes, keys,
+                 num_items, num_segments, offsets.GetPointer(util::DEVICE),
+                 offsets.GetPointer(util::DEVICE) + 1, begin_bit, end_bit,
+                 stream, debug_synchronous);
 
     if(retval) return retval;
 
@@ -288,9 +286,12 @@ cudaError_t cubSortPairs(util::Array1D<uint64_t, char> &temp_space,
       values_out.GetPointer(util::DEVICE));
 
   size_t request_bytes = 0;
-  retval = cub::DispatchRadixSort<false, KeyT, ValueT, SizeT>::Dispatch(
-      NULL, request_bytes, keys, values, num_items, begin_bit, end_bit, false,
-      stream, debug_synchronous);
+  retval = cub::DeviceRadixSort::
+      SortPairs(NULL, request_bytes, keys_in.GetPointer(util::DEVICE),
+                keys_out.GetPointer(util::DEVICE),
+                values_in.GetPointer(util::DEVICE),
+                values_out.GetPointer(util::DEVICE), num_items, begin_bit,
+                end_bit, stream, debug_synchronous);
   if (retval) return retval;
   // util::PrintMsg("num_items = " + std::to_string(num_items)
   //    + ", request_bytes = " + std::to_string(request_bytes));
@@ -298,9 +299,13 @@ cudaError_t cubSortPairs(util::Array1D<uint64_t, char> &temp_space,
   retval = temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
-  retval = cub::DispatchRadixSort<false, KeyT, ValueT, SizeT>::Dispatch(
-      temp_space.GetPointer(util::DEVICE), request_bytes, keys, values,
-      num_items, begin_bit, end_bit, false, stream, debug_synchronous);
+  retval = cub::DeviceRadixSort::
+      SortPairs(temp_space.GetPointer(util::DEVICE), request_bytes,
+                keys_in.GetPointer(util::DEVICE),
+                keys_out.GetPointer(util::DEVICE),
+                values_in.GetPointer(util::DEVICE),
+                values_out.GetPointer(util::DEVICE), num_items, begin_bit,
+                end_bit, stream, debug_synchronous);
   if (retval) return retval;
 
   if (keys.Current() != keys_out.GetPointer(util::DEVICE)) {
@@ -342,17 +347,27 @@ cudaError_t cubSortPairsDescending(util::Array1D<uint64_t, char> &temp_space,
       values_out.GetPointer(util::DEVICE));
 
   size_t request_bytes = 0;
-  retval = cub::DispatchRadixSort<true, KeyT, ValueT, SizeT>::Dispatch(
-      NULL, request_bytes, keys, values, num_items, begin_bit, end_bit, false,
-      stream, debug_synchronous);
+  
+  retval = cub::DeviceRadixSort::
+      SortPairsDescending(NULL, request_bytes,
+                          keys_in.GetPointer(util::DEVICE),
+                          keys_out.GetPointer(util::DEVICE),
+                          values_in.GetPointer(util::DEVICE),
+                          values_out.GetPointer(util::DEVICE), num_items,
+                          begin_bit, end_bit, stream, debug_synchronous);
   if (retval) return retval;
 
   retval = temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
-  retval = cub::DispatchRadixSort<true, KeyT, ValueT, SizeT>::Dispatch(
-      temp_space.GetPointer(util::DEVICE), request_bytes, keys, values,
-      num_items, begin_bit, end_bit, false, stream, debug_synchronous);
+  retval = cub::DeviceRadixSort::
+      SortPairsDescending((void*)temp_space.GetPointer(util::DEVICE),
+                          request_bytes, keys_in.GetPointer(util::DEVICE),
+                          keys_out.GetPointer(util::DEVICE),
+                          values_in.GetPointer(util::DEVICE),
+                          values_out.GetPointer(util::DEVICE),
+                          num_items, begin_bit, end_bit, stream,
+                          debug_synchronous);
   if (retval) return retval;
 
   if (keys.Current() != keys_out.GetPointer(util::DEVICE)) {
@@ -387,31 +402,28 @@ cudaError_t cubSegmentedSortPairs(
     bool debug_synchronous = false) {
   cudaError_t retval = cudaSuccess;
 
-  cub::DoubleBuffer<KeyT> keys(
-      const_cast<KeyT *>(keys_in.GetPointer(util::DEVICE)),
-      keys_out.GetPointer(util::DEVICE));
-  cub::DoubleBuffer<ValueT> values(
-      const_cast<ValueT *>(values_in.GetPointer(util::DEVICE)),
-      values_out.GetPointer(util::DEVICE));
-
   size_t request_bytes = 0;
-  retval =
-      cub::DispatchSegmentedRadixSort<false, KeyT, ValueT, SizeT *, SizeT>::
-          Dispatch(NULL, request_bytes, keys, values, num_items, num_segments,
-                   seg_offsets.GetPointer(util::DEVICE),
-                   seg_offsets.GetPointer(util::DEVICE) + 1, begin_bit, end_bit,
-                   false, stream, debug_synchronous);
+  retval = cub::DeviceSegmentedRadixSort::
+      SortPairs(NULL, request_bytes,
+                keys_in.GetPointer(util::DEVICE),
+                keys_out.GetPointer(util::DEVICE),
+                values_in.GetPointer(util::DEVICE),
+                values_out.GetPointer(util::DEVICE), num_items, num_segments,
+                seg_offsets.GetPointer(util::DEVICE),
+                seg_offsets.GetPointer(util::DEVICE) + 1, begin_bit, end_bit,
+                stream, debug_synchronous);
   if (retval) return retval;
 
   retval = temp_space.EnsureSize_(request_bytes, util::DEVICE);
   if (retval) return retval;
 
-  retval = cub::
-      DispatchSegmentedRadixSort<false, KeyT, ValueT, SizeT *, SizeT>::Dispatch(
-          temp_space.GetPointer(util::DEVICE), request_bytes, keys, values,
-          num_items, num_segments, seg_offsets.GetPointer(util::DEVICE),
-          seg_offsets.GetPointer(util::DEVICE) + 1, begin_bit, end_bit, false,
-          stream, debug_synchronous);
+  retval = cub::DeviceSegmentedRadixSort::
+      SortPairs(temp_space.GetPointer(util::DEVICE), request_bytes,
+                keys_in, keys_out, values_in, values_out, num_items,
+                num_segments, num_items, num_segments,
+                seg_offsets.GetPointer(util::DEVICE),
+                seg_offsets.GetPointer(util::DEVICE) + 1, begin_bit,
+                end_bit, stream, debug_synchronous);
   if (retval) return retval;
 
   return retval;


### PR DESCRIPTION
Internal CUB APIs in sort, select, and reduce are changed to external ones.
Fixes #857.