### PR TITLE
lambda function for SpGEMM

### DIFF
--- a/benchmarks/spgemm_bench.cu
+++ b/benchmarks/spgemm_bench.cu
@@ -108,7 +108,7 @@ void spgemm_bench(nvbench::state& state) {
   thrust::device_vector<vertex_t> row_indices(b_csr.number_of_nonzeros);
   thrust::device_vector<edge_t> column_offsets(b_csr.number_of_columns + 1);
 
-  auto B = graph::build::from_csr<space, graph::view_t::csc>(
+  auto B = graph::build::from_csr<memory_space_t::device, graph::view_t::csc>(
       b_csr.number_of_rows, b_csr.number_of_columns, b_csr.number_of_nonzeros,
       b_csr.row_offsets.data().get(), b_csr.column_indices.data().get(),
       b_csr.nonzero_values.data().get(),

--- a/benchmarks/spgemm_bench.cu
+++ b/benchmarks/spgemm_bench.cu
@@ -100,10 +100,11 @@ void spgemm_bench(nvbench::state& state) {
   csr_t b_csr;
   b_csr.from_coo(mm.load(filename_b));
 
-  auto B_csr = graph::build::from_csr<memory_space_t::device, graph::view_t::csr>(
-      b_csr.number_of_rows, b_csr.number_of_columns, b_csr.number_of_nonzeros,
-      b_csr.row_offsets.data().get(), b_csr.column_indices.data().get(),
-      b_csr.nonzero_values.data().get());
+  auto B_csr =
+      graph::build::from_csr<memory_space_t::device, graph::view_t::csr>(
+          b_csr.number_of_rows, b_csr.number_of_columns,
+          b_csr.number_of_nonzeros, b_csr.row_offsets.data().get(),
+          b_csr.column_indices.data().get(), b_csr.nonzero_values.data().get());
 
   thrust::device_vector<vertex_t> row_indices(b_csr.number_of_nonzeros);
   thrust::device_vector<edge_t> column_offsets(b_csr.number_of_columns + 1);
@@ -111,16 +112,16 @@ void spgemm_bench(nvbench::state& state) {
   auto B = graph::build::from_csr<memory_space_t::device, graph::view_t::csc>(
       b_csr.number_of_rows, b_csr.number_of_columns, b_csr.number_of_nonzeros,
       b_csr.row_offsets.data().get(), b_csr.column_indices.data().get(),
-      b_csr.nonzero_values.data().get(),
-      row_indices.data().get(),         
+      b_csr.nonzero_values.data().get(), row_indices.data().get(),
       column_offsets.data().get());
 
   csr_t C;
 
   // --
   // Run SPGEMM with NVBench
-  state.exec(nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) { gunrock::spgemm::run(A, B_csr, B, C); });
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    gunrock::spgemm::run(A, B_csr, B, C);
+  });
 }
 
 int main(int argc, char** argv) {

--- a/examples/algorithms/spgemm/spgemm.cu
+++ b/examples/algorithms/spgemm/spgemm.cu
@@ -53,8 +53,7 @@ void test_spmv(int num_arguments, char** argument_array) {
   auto B = graph::build::from_csr<space, graph::view_t::csc>(
       b_csr.number_of_rows, b_csr.number_of_columns, b_csr.number_of_nonzeros,
       b_csr.row_offsets.data().get(), b_csr.column_indices.data().get(),
-      b_csr.nonzero_values.data().get(),
-      row_indices.data().get(),         
+      b_csr.nonzero_values.data().get(), row_indices.data().get(),
       column_offsets.data().get());
 
   /// Let's use CSR representation

--- a/include/gunrock/algorithms/spgemm.hxx
+++ b/include/gunrock/algorithms/spgemm.hxx
@@ -20,11 +20,12 @@
 namespace gunrock {
 namespace spgemm {
 
-template <typename graph_t>
+template <typename graph_t, typename graph_type>
 struct param_t {
   graph_t& A;
-  graph_t& B;
-  param_t(graph_t& _A, graph_t& _B) : A(_A), B(_B) {}
+  graph_t& B_csr;
+  graph_type& B;
+  param_t(graph_t& _A, graph_t& _B_csr, graph_type& _B) : A(_A), B_csr(_B_csr), B(_B) {}
 };
 
 template <typename csr_t>
@@ -95,6 +96,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     auto policy = this->context->get_context(0)->execution_policy();
 
     auto& A = P->param.A;
+    auto& B_csr = P->param.B_csr;
     auto& B = P->param.B;
     auto& C = P->result.C;
 
@@ -119,7 +121,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
                                 weight_t const& nz     // weight (nonzero).
                                 ) -> bool {
       // Compute number of nonzeros of the sparse-matrix C for each row.
-      math::atomic::add(&(estimated_nz_ptr[m]), B.get_number_of_neighbors(k));
+      math::atomic::add(&(estimated_nz_ptr[m]), B_csr.get_number_of_neighbors(k));
       return false;
     };
 
@@ -131,12 +133,12 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
 
     /// Step X. Calculate upperbound of C's row-offsets.
     thrust::exclusive_scan(policy, P->estimated_nz_per_row.begin(),
-                           P->estimated_nz_per_row.end(), row_offsets.begin(),
+                           P->estimated_nz_per_row.end() + 1, row_offsets.begin(),
                            edge_t(0), thrust::plus<edge_t>());
 
-    thrust::copy(row_offsets.begin() + A.get_number_of_vertices() - 1,
-                 row_offsets.begin() + A.get_number_of_vertices(),
-                 row_offsets.begin() + A.get_number_of_vertices());
+    // thrust::copy(row_offsets.begin() + A.get_number_of_vertices() - 1,
+    //              row_offsets.begin() + A.get_number_of_vertices(),
+    //              row_offsets.begin() + A.get_number_of_vertices());
 
     /// Step X. Calculate the upperbound of total number of nonzeros in the
     /// sparse-matrix C.
@@ -154,41 +156,97 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
     vertex_t* col_ind = column_indices.data().get();
     weight_t* nz_vals = nonzero_values.data().get();
 
-    /// Step X. Calculate C's column indices and values.
-    auto gustavsons =
-        [=] __host__ __device__(
-            vertex_t const& m,  // ... source (A: row index)
-            vertex_t const& k,  // neighbor (A: column index or B: row index)
-            edge_t const& a_nz_idx,  // edge (A: row ↦ column)
-            weight_t const& a_nz     // weight (A: nonzero).
-            ) -> bool {
-      // Get the number of nonzeros in row k of sparse-matrix B.
-      auto offset = B.get_starting_edge(k);
-      auto nnz = B.get_number_of_neighbors(k);
-      auto c_offset = thread::load(&row_off[m]);
+    auto naive_spgemm = [=] __host__ __device__(vertex_t const& row) -> bool {
+      // Get the number of nonzeros in row of sparse-matrix A.
+      auto a_offset = A.get_starting_edge(row);
+      auto a_nnz = A.get_number_of_neighbors(row);
+      auto c_offset = thread::load(&row_off[row]);
+      auto n = 0;
+      bool increment = false;
 
-      // Loop over all the nonzeros in row k of sparse-matrix B.
-      for (edge_t b_nz_idx = offset; b_nz_idx < (offset + nnz); ++b_nz_idx) {
-        auto n = B.get_destination_vertex(b_nz_idx);
-        auto b_nz = B.get_edge_weight(b_nz_idx);
+      // iterate over the columns of B.
+      for (edge_t b_col = 0; b_col < B.get_number_of_vertices(); ++b_col) {
+        // Get the number of nonzeros in column of sparse-matrix B.
+        auto b_offset = B.get_starting_edge(b_col);
+        auto b_nnz = B.get_number_of_neighbors(b_col);
+        auto b_nz_idx = b_offset;
+        auto a_nz_idx = a_offset;
 
-        // Calculate c's nonzero index.
-        std::size_t c_nz_idx = c_offset + n;
+        // For the row in A, multiple with corresponding element in B.
+        while ((a_nz_idx < (a_offset + a_nnz)) && (b_nz_idx < (b_offset + b_nnz))) {
+          auto a_col = A.get_destination_vertex(a_nz_idx);
+          auto b_row = B.get_source_vertex(b_nz_idx);
 
-        // Assign column index.
-        thread::store(&col_ind[c_nz_idx], n);
+          //  Multiply if the column of A equals row of B.
+          if (a_col == b_row) {
+              auto a_nz = A.get_edge_weight(a_nz_idx);
+              auto b_nz = B.get_edge_weight(b_nz_idx);
 
-        // Accumulate the nonzero value.
-        math::atomic::add(nz_vals + c_nz_idx, a_nz * b_nz);
+              // Calculate  C's nonzero index.
+              std::size_t c_nz_idx = c_offset + n;
+              assert(c_nz_idx < estimated_nzs);
+
+              // Assign column index.
+              thread::store(&col_ind[c_nz_idx], n);
+
+              // Accumulate the nonzero value.
+              nz_vals[c_nz_idx] += a_nz * b_nz;
+
+              a_nz_idx++;
+              b_nz_idx++;
+
+              increment = true;
+          }
+          else if (a_col < b_row) a_nz_idx++;
+          else b_nz_idx++;
+        }
+        // a non zero element was stored in C, so we increment n
+        if (increment) {
+          n++;
+          increment = false;
+        }
       }
       return false;
     };
 
-    operators::advance::execute<operators::load_balance_t::block_mapped,
-                                operators::advance_direction_t::forward,
-                                operators::advance_io_type_t::graph,
-                                operators::advance_io_type_t::none>(
-        A, E, gustavsons, context);
+    operators::parallel_for::execute<operators::parallel_for_each_t::vertex>(
+        A, naive_spgemm, context);
+
+    /// Step X. Calculate C's column indices and values.
+    // auto gustavsons =
+    //     [=] __host__ __device__(
+    //         vertex_t const& m,  // ... source (A: row index)
+    //         vertex_t const& k,  // neighbor (A: column index or B: row index)
+    //         edge_t const& a_nz_idx,  // edge (A: row ↦ column)
+    //         weight_t const& a_nz     // weight (A: nonzero).
+    //         ) -> bool {
+    //   // Get the number of nonzeros in row k of sparse-matrix B.
+    //   auto offset = B.get_starting_edge(k);
+    //   auto nnz = B.get_number_of_neighbors(k);
+    //   auto c_offset = thread::load(&row_off[m]);
+
+    //   // Loop over all the nonzeros in row k of sparse-matrix B.
+    //   for (edge_t b_nz_idx = offset; b_nz_idx < (offset + nnz); ++b_nz_idx) {
+    //     auto n = B.get_destination_vertex(b_nz_idx);
+    //     auto b_nz = B.get_edge_weight(b_nz_idx);
+
+    //     // Calculate c's nonzero index.
+    //     std::size_t c_nz_idx = c_offset + n;
+
+    //     // Assign column index.
+    //     thread::store(&col_ind[c_nz_idx], n);
+
+    //     // Accumulate the nonzero value.
+    //     math::atomic::add(nz_vals + c_nz_idx, a_nz * b_nz);
+    //   }
+    //   return false;
+    // };
+
+    // operators::advance::execute<operators::load_balance_t::block_mapped,
+    //                             operators::advance_direction_t::forward,
+    //                             operators::advance_io_type_t::graph,
+    //                             operators::advance_io_type_t::none>(
+    //     A, E, gustavsons, context);
 
     /// Step X. Fix-up, i.e., remove overestimated nonzeros and rellocate the
     /// storage as necessary.
@@ -256,18 +314,19 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
   }
 };  // struct enactor_t
 
-template <typename graph_t, typename csr_t>
+template <typename graph_t, typename graph_type, typename csr_t>
 float run(graph_t& A,
-          graph_t& B,
+          graph_t& B_csr,
+          graph_type& B,
           csr_t& C,
           std::shared_ptr<gcuda::multi_context_t> context =
               std::shared_ptr<gcuda::multi_context_t>(
                   new gcuda::multi_context_t(0))  // Context
 ) {
-  using param_type = param_t<graph_t>;
+  using param_type = param_t<graph_t, graph_type>;
   using result_type = result_t<csr_t>;
 
-  param_type param(A, B);
+  param_type param(A, B_csr, B);
   result_type result(C);
 
   using problem_type = problem_t<graph_t, param_type, result_type>;

--- a/include/gunrock/framework/frontier/vector_frontier.hxx
+++ b/include/gunrock/framework/frontier/vector_frontier.hxx
@@ -94,18 +94,14 @@ class vector_frontier_t {
    * @brief Get the capacity (number of elements possible).
    * @return std::size_t
    */
-  std::size_t get_capacity() const {
-    return p_storage.get()->capacity();
-  }
+  std::size_t get_capacity() const { return p_storage.get()->capacity(); }
 
   /**
    * @brief Get the resizing factor used to scale the frontier size.
    *
    * @return resizing factor for the frontier.
    */
-  float get_resizing_factor() const {
-    return resizing_factor;
-  }
+  float get_resizing_factor() const { return resizing_factor; }
 
   /**
    * @brief Get the element (const) at the specified index.
@@ -149,9 +145,7 @@ class vector_frontier_t {
    *
    * @param factor a float defining the resizing factor, 1.0f means no scaling.
    */
-  void set_resizing_factor(float factor) {
-    resizing_factor = factor;
-  }
+  void set_resizing_factor(float factor) { resizing_factor = factor; }
 
   /**
    * @brief Set how many number of elements the frontier contains. Note, this is
@@ -177,27 +171,21 @@ class vector_frontier_t {
    *
    * @return type_t* data pointer.
    */
-  auto data() {
-    return raw_pointer_cast(p_storage.get()->data());
-  }
+  auto data() { return raw_pointer_cast(p_storage.get()->data()); }
 
   /**
    * @brief Access to the begin pointer of the frontier.
    *
    * @return type_t* begin pointer.
    */
-  auto begin() {
-    return this->data();
-  }
+  auto begin() { return this->data(); }
 
   /**
    * @brief Access to the end pointer of the frontier.
    *
    * @return type_t* end pointer.
    */
-  auto end() {
-    return this->begin() + this->get_number_of_elements();
-  }
+  auto end() { return this->begin() + this->get_number_of_elements(); }
 
   /**
    * @brief Checks if the frontier is empty.
@@ -205,9 +193,7 @@ class vector_frontier_t {
    * @return true
    * @return false
    */
-  bool is_empty() const {
-    return (this->get_number_of_elements() == 0);
-  }
+  bool is_empty() const { return (this->get_number_of_elements() == 0); }
 
   /**
    * @brief (vertex-like) push back a value to the frontier. Can only be done on

--- a/include/gunrock/framework/operators/configs.hxx
+++ b/include/gunrock/framework/operators/configs.hxx
@@ -25,20 +25,27 @@ namespace operators {
  * respective underlying load-balanced advance kernel to use. The following
  * table attempts to summarize these techniques:
  *  https://gist.github.com/neoblizz/fc4a3da5f4fc51f2f2a90753b5c49762
- * 
+ *
  * clang-format off
- * 
- * | Technique | Thread-Mapped | Block-Mapped | Warp-Mapped | Bucketing | Non-Zero Split | Merge-Path | Work Stealing |
+ *
+ * | Technique | Thread-Mapped | Block-Mapped | Warp-Mapped | Bucketing |
+ * Non-Zero Split | Merge-Path | Work Stealing |
  * |-|-|-|-|-|-|-|-|
- * | Summary | 1 element per thread | Block-sized elements per block | Warp-sized elements per warp | Buckets per threads, warps, blocks | Equal non-zeros per thread | Equal work-item (input and output) per thread | Steal work from threads when starving |
- * | Number of Scans | 1 | 2 | 2 | Unknown | Unknown | 1 | Unknown |
- * | Type of Scans | Device | Device (not-required), Block | Device, Warp | Unknown | Unknown | Device | Unknown |
- * | Binary-Search | N/A | N/A | N/A | N/A | 1 | 2 | N/A |
- * | Static or Dynamic | Static | Static | Static | Dynamic | Static | Static | Dynamic |
- * | Overall Estimated Overhead | None | Minor | Minor | Medium | High | Very High | High |
- * | Quality of Balancing | Poor (Data dependent) | HW Block-Scheduler dependent (Fair) | HW Warp-Scheduler dependent (Fair) | Good | Perfect Non-zeros quality | Perfect input and output | Medium |
- * | Storage Requirement | Input Size (for scan) | Input Size (for scan) | Input Size (for scan) | Unknown | Unknown | Unknown | Unknown |
- * 
+ * | Summary | 1 element per thread | Block-sized elements per block |
+ * Warp-sized elements per warp | Buckets per threads, warps, blocks | Equal
+ * non-zeros per thread | Equal work-item (input and output) per thread | Steal
+ * work from threads when starving | | Number of Scans | 1 | 2 | 2 | Unknown |
+ * Unknown | 1 | Unknown | | Type of Scans | Device | Device (not-required),
+ * Block | Device, Warp | Unknown | Unknown | Device | Unknown | | Binary-Search
+ * | N/A | N/A | N/A | N/A | 1 | 2 | N/A | | Static or Dynamic | Static | Static
+ * | Static | Dynamic | Static | Static | Dynamic | | Overall Estimated Overhead
+ * | None | Minor | Minor | Medium | High | Very High | High | | Quality of
+ * Balancing | Poor (Data dependent) | HW Block-Scheduler dependent (Fair) | HW
+ * Warp-Scheduler dependent (Fair) | Good | Perfect Non-zeros quality | Perfect
+ * input and output | Medium | | Storage Requirement | Input Size (for scan) |
+ * Input Size (for scan) | Input Size (for scan) | Unknown | Unknown | Unknown |
+ * Unknown |
+ *
  * clang-format on
  *
  * @todo somehow make that gist part of the in-code comments.


### PR DESCRIPTION
This PR adds the lambda function for SpGEMM. 

All checks passed except documentation. Not sure why...

Some updates that can be done for the future:
- Using advance instead of parallel-for
- When graph view_t can do both CSR and CSC in the same view, the inputs for B can be updated. Currently, the 2 separate views are passed to spgemm::run() as parameters