### PR TITLE
Fix MST bug introduced with par_nosync

### DIFF
--- a/include/gunrock/algorithms/mst.hxx
+++ b/include/gunrock/algorithms/mst.hxx
@@ -235,7 +235,7 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
         add_to_mst,  // lambda function
         context      // context
     );
-    
+
     // Need to sync before checking the value of not_decremented
     cudaDeviceSynchronize();
 

--- a/include/gunrock/algorithms/mst.hxx
+++ b/include/gunrock/algorithms/mst.hxx
@@ -235,6 +235,9 @@ struct enactor_t : gunrock::enactor_t<problem_t> {
         add_to_mst,  // lambda function
         context      // context
     );
+    
+    // Need to sync before checking the value of not_decremented
+    cudaDeviceSynchronize();
 
     // Throw an exception if the number of super vertices has not been
     // decremented


### PR DESCRIPTION
The switch to par_nosync introduced a bug in MST where it would exit early. An exit condition was checked asynchronously before the value was updated. This fixes that issue.