### PR TITLE
[WIP] Logarithmic Radix Binning (LRB) load-balancing for advance operator

### DIFF
--- a/include/gunrock/framework/operators/advance/advance.hxx
+++ b/include/gunrock/framework/operators/advance/advance.hxx
@@ -20,7 +20,7 @@
 
 #include <gunrock/framework/operators/advance/thread_mapped.hxx>
 #include <gunrock/framework/operators/advance/block_mapped.hxx>
-#include <gunrock/framework/operators/advance/bucketing.hxx>
+#include <gunrock/framework/operators/advance/lrb.hxx>
 #include <gunrock/framework/operators/advance/merge_path.hxx>
 
 #if __HIP_PLATFORM_NVIDIA__
@@ -122,6 +122,9 @@ void execute(graph_t& G,
     } else if (lb == load_balance_t::block_mapped) {
       block_mapped::execute<direction, input_type, output_type>(
           G, op, *input, *output, *context0);
+    } else if (lb == load_balance_t::lrb) {
+      lrb::execute<direction, input_type, output_type>(
+          G, op, *input, *output, segments, *context0);
     } else {
       error::throw_if_exception(hipErrorUnknown, "Advance type not supported.");
     }
@@ -269,6 +272,10 @@ void execute_runtime(graph_t& G,
             advance_io_type_t::vertices, advance_io_type_t::vertices>(
         G, E, op, context, swap_buffers);
 #endif
+  } else if (lb == load_balance_t::lrb) {
+    execute<load_balance_t::lrb, advance_direction_t::forward,
+            advance_io_type_t::vertices, advance_io_type_t::vertices>(
+        G, E, op, context, swap_buffers);
   } else {
     error::throw_if_exception(hipErrorUnknown, "Load balance type not supported.");
   }

--- a/include/gunrock/framework/operators/advance/lrb.hxx
+++ b/include/gunrock/framework/operators/advance/lrb.hxx
@@ -1,0 +1,628 @@
+/**
+ * @file lrb.hxx
+ * @author Muhammad Osama (mosama@ucdavis.edu)
+ * @brief Logarithmic Radix Binning (LRB) load-balancing for advance operator.
+ * @date 2026-01-21
+ *
+ * @copyright Copyright (c) 2026
+ *
+ * @par Overview
+ * LRB (Logarithmic Radix Binning) is a load-balancing technique that bins
+ * frontier vertices by their degree (work size) using logarithmic bucketing.
+ * Vertices with similar degrees (2^b to 2^(b+1)) are grouped together,
+ * enabling efficient load-balanced processing.
+ *
+ * @par Algorithm
+ * 1. Bin Count: For each vertex v with degree d, compute bin = __clz(d)
+ * 2. Prefix Sum: Compute prefix sum over bins to determine starting positions
+ * 3. Reorder: Reorganize vertices into bins based on their work size
+ * 4. Process: Handle each bin with appropriate strategy based on size
+ *
+ * @par References
+ * Fox et al., "Improving Scheduling for Irregular Applications with
+ * Logarithmic Radix Binning", IEEE HPEC 2019
+ * https://github.com/ogreen/segmented-sort/blob/main/lrb_sort.cuh
+ */
+
+#pragma once
+
+#include <gunrock/util/math.hxx>
+#include <gunrock/cuda/cuda.hxx>
+#include <gunrock/framework/operators/configs.hxx>
+#include <gunrock/framework/operators/advance/helpers.hxx>
+
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+
+// Include appropriate CUB library based on compiler
+#if defined(__CUDACC__) && !defined(__HIP__)
+  // Pure CUDA (NVCC without HIP): Use CUB
+  #include <cub/device/device_scan.cuh>
+  namespace cub_namespace = cub;
+#else
+  // HIP compiler (works for both NVIDIA and AMD platforms): Use hipCUB
+  #ifdef __HIP_PLATFORM_AMD__
+    #ifdef gfx942
+      #pragma push_macro("gfx942")
+      #undef gfx942
+    #endif
+    #ifdef gfx950
+      #pragma push_macro("gfx950")
+      #undef gfx950
+    #endif
+    #ifdef gfx90a
+      #pragma push_macro("gfx90a")
+      #undef gfx90a
+    #endif
+  #endif
+  #include <hipcub/hipcub.hpp>
+  #ifdef __HIP_PLATFORM_AMD__
+    #ifdef gfx942
+      #pragma pop_macro("gfx942")
+    #endif
+    #ifdef gfx950
+      #pragma pop_macro("gfx950")
+    #endif
+    #ifdef gfx90a
+      #pragma pop_macro("gfx90a")
+    #endif
+  #endif
+  namespace cub_namespace = hipcub;
+#endif
+
+namespace gunrock {
+namespace operators {
+namespace advance {
+namespace lrb {
+
+// Number of bins for 32-bit integers (0 to 32 leading zeros)
+constexpr int NUM_BINS = 33;
+
+// Bin thresholds for different processing strategies
+constexpr int BIN_LARGE_START = 20;   // 2^20 = ~1M edges, use CUB
+constexpr int BIN_MEDIUM_START = 28;  // 2^28+, use block kernels
+constexpr int BIN_SMALL_START = 31;   // 2^31+, use simple kernels
+
+/**
+ * @brief Compute bin index for a given degree using count-leading-zeros.
+ *
+ * @tparam edge_t Edge type (typically int or int64_t)
+ * @param degree Number of neighbors for a vertex
+ * @return int Bin index (0-32 for 32-bit, 0-64 for 64-bit)
+ */
+template <typename edge_t>
+__device__ __host__ __forceinline__ int compute_bin(edge_t degree) {
+  if (degree == 0)
+    return NUM_BINS - 1;  // Empty vertices go to last bin
+  
+  // Use count-leading-zeros intrinsic
+  if constexpr (sizeof(edge_t) == 4) {
+    return __clz((int)degree);
+  } else if constexpr (sizeof(edge_t) == 8) {
+    return __clzll((long long)degree);
+  } else {
+    // Fallback for other sizes
+    return __clz((int)degree);
+  }
+}
+
+/**
+ * @brief Kernel to count vertices per bin using shared memory for efficiency.
+ *
+ * @tparam graph_t Graph type
+ * @tparam input_iterator_t Input iterator type
+ * @param G Graph object
+ * @param input Input frontier or iterator
+ * @param bins Output bin counts (size NUM_BINS)
+ * @param input_size Number of elements in input frontier
+ */
+template <typename graph_t, typename input_iterator_t>
+__global__ void bin_count_kernel(graph_t G,
+                                   input_iterator_t input,
+                                   int32_t* bins,
+                                   std::size_t input_size) {
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+  
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  
+  // Shared memory for local bin counts to reduce global atomic contention
+  __shared__ int32_t local_bins[NUM_BINS];
+  
+  int tid = threadIdx.x;
+  if (tid < NUM_BINS) {
+    local_bins[tid] = 0;
+  }
+  __syncthreads();
+  
+  // Each thread processes one vertex
+  if (i < input_size) {
+    vertex_t v = input[i];
+    
+    // Skip invalid vertices
+    if (!gunrock::util::limits::is_valid(v))
+      return;
+    
+    edge_t degree = G.get_number_of_neighbors(v);
+    int bin = compute_bin(degree);
+    
+    // Atomically increment local bin count
+    atomicAdd(&local_bins[bin], 1);
+  }
+  
+  __syncthreads();
+  
+  // Reduce local bins to global bins
+  if (tid < NUM_BINS) {
+    atomicAdd(&bins[tid], local_bins[tid]);
+  }
+}
+
+/**
+ * @brief Kernel to compute prefix sum over bins.
+ * 
+ * This is a simple serial kernel since we only have 33 bins.
+ * For larger bin counts, consider using CUB's device-level scan.
+ *
+ * @param bins Input bin counts (size NUM_BINS)
+ * @param prefix_bins Output prefix sum (size NUM_BINS+1)
+ */
+__global__ void bin_prefix_kernel(const int32_t* bins, int32_t* prefix_bins) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  
+  prefix_bins[0] = 0;
+  for (int b = 0; b < NUM_BINS; b++) {
+    prefix_bins[b + 1] = prefix_bins[b] + bins[b];
+  }
+}
+
+/**
+ * @brief Kernel to compute bin membership for each vertex (Phase 1 optimization).
+ * Instead of reordering vertices, we just record which bin each belongs to.
+ *
+ * @tparam graph_t Graph type
+ * @tparam input_iterator_t Input iterator type
+ * @param G Graph object
+ * @param input Input frontier or iterator
+ * @param bin_membership Output array: bin_membership[i] = bin index for vertex i
+ * @param input_size Number of elements in input frontier
+ */
+template <typename graph_t, typename input_iterator_t>
+__global__ void compute_bin_membership_kernel(graph_t G,
+                                                input_iterator_t input,
+                                                int32_t* bin_membership,
+                                                std::size_t input_size) {
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+  
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  
+  if (i >= input_size)
+    return;
+  
+  vertex_t v = input[i];
+  
+  if (!gunrock::util::limits::is_valid(v)) {
+    bin_membership[i] = NUM_BINS - 1;  // Invalid vertices go to last bin
+    return;
+  }
+  
+  edge_t degree = G.get_number_of_neighbors(v);
+  bin_membership[i] = compute_bin(degree);
+}
+
+/**
+ * @brief Kernel to count vertices per bin after sorting (Phase 1 optimization).
+ *
+ * @param sorted_bin_membership Sorted bin membership array
+ * @param bins Output bin counts
+ * @param input_size Number of elements
+ */
+__global__ void count_sorted_bins_kernel(int32_t* sorted_bin_membership,
+                                           int32_t* bins,
+                                           std::size_t input_size) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  
+  if (i >= input_size)
+    return;
+  
+  int my_bin = sorted_bin_membership[i];
+  atomicAdd(&bins[my_bin], 1);
+}
+
+/**
+ * @brief Kernel to process small bins using indirect indexing (Phase 1 optimized).
+ * Uses simple per-thread processing without vertex reordering.
+ *
+ * @tparam graph_t Graph type
+ * @tparam operator_t Operator type
+ * @tparam frontier_t Frontier type (or iterator)
+ * @param G Graph object
+ * @param op User-defined operator
+ * @param input Original input frontier
+ * @param sorted_indices Indices sorted by bin
+ * @param output Output frontier
+ * @param segments Segment offsets (output positions for original vertices)
+ * @param start_idx Starting index in sorted_indices array
+ * @param end_idx Ending index in sorted_indices array
+ */
+template <advance_io_type_t output_type,
+          advance_io_type_t input_type,
+          typename graph_t,
+          typename operator_t,
+          typename input_iterator_t,
+          typename output_iterator_t,
+          typename work_tiles_t>
+__global__ void process_small_bins_kernel(graph_t G,
+                                            operator_t op,
+                                            input_iterator_t input,
+                                            int32_t* sorted_indices,
+                                            output_iterator_t output,
+                                            work_tiles_t* segments,
+                                            int start_idx,
+                                            int end_idx) {
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+  using weight_t = typename graph_t::weight_type;
+  
+  int sorted_pos = threadIdx.x + blockIdx.x * blockDim.x + start_idx;
+  
+  if (sorted_pos >= end_idx)
+    return;
+  
+  // Get the original index of this vertex
+  int orig_idx = sorted_indices[sorted_pos];
+  
+  // Get the vertex from original input
+  vertex_t v;
+  if constexpr (input_type == advance_io_type_t::graph) {
+    v = static_cast<vertex_t>(orig_idx);
+  } else {
+    v = input[orig_idx];
+  }
+  
+  if (!gunrock::util::limits::is_valid(v))
+    return;
+  
+  // Use original segments (no recomputation needed!)
+  edge_t output_start = segments[orig_idx];
+  edge_t output_end = segments[orig_idx + 1];
+  edge_t degree = output_end - output_start;
+  
+  // Get the starting edge in the graph for this vertex
+  edge_t graph_edge_start = G.get_starting_edge(v);
+  
+  // Process all edges for this vertex
+  for (edge_t local_e = 0; local_e < degree; local_e++) {
+    edge_t graph_e = graph_edge_start + local_e;
+    edge_t output_pos = output_start + local_e;
+    
+    vertex_t n = G.get_destination_vertex(graph_e);
+    weight_t w = G.get_edge_weight(graph_e);
+    
+    bool cond = op(v, n, graph_e, w);
+    
+    if constexpr (output_type != advance_io_type_t::none) {
+      output[output_pos] = cond ? n : gunrock::numeric_limits<vertex_t>::invalid();
+    }
+  }
+}
+
+/**
+ * @brief Kernel to process medium bins using indirect indexing (Phase 1 optimized).
+ * Uses block-level processing with binary search, no vertex reordering.
+ *
+ * @tparam THREADS_PER_BLOCK Block size
+ * @tparam graph_t Graph type
+ * @tparam operator_t Operator type
+ * @tparam frontier_t Frontier type
+ * @param G Graph object
+ * @param op User-defined operator
+ * @param input Original input frontier
+ * @param sorted_indices Indices sorted by bin
+ * @param output Output frontier
+ * @param segments Segment offsets (for original vertices)
+ * @param start_idx Starting index in sorted_indices array
+ * @param end_idx Ending index in sorted_indices array
+ */
+template <unsigned int THREADS_PER_BLOCK,
+          advance_io_type_t output_type,
+          advance_io_type_t input_type,
+          typename graph_t,
+          typename operator_t,
+          typename input_iterator_t,
+          typename output_iterator_t,
+          typename work_tiles_t>
+__global__ void process_medium_bins_kernel(graph_t G,
+                                             operator_t op,
+                                             input_iterator_t input,
+                                             int32_t* sorted_indices,
+                                             output_iterator_t output,
+                                             work_tiles_t* segments,
+                                             int start_idx,
+                                             int end_idx) {
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+  using weight_t = typename graph_t::weight_type;
+  
+  // Shared memory for vertices, graph edge starts, and output positions
+  __shared__ vertex_t vertices[THREADS_PER_BLOCK];
+  __shared__ edge_t graph_edge_starts[THREADS_PER_BLOCK];
+  __shared__ edge_t output_starts[THREADS_PER_BLOCK];
+  __shared__ edge_t degrees[THREADS_PER_BLOCK];
+  
+  int sorted_pos = blockIdx.x * blockDim.x + start_idx;
+  int local_idx = threadIdx.x;
+  
+  // Load vertices using indirect indexing
+  if (sorted_pos + local_idx < end_idx) {
+    int orig_idx = sorted_indices[sorted_pos + local_idx];
+    
+    vertex_t v;
+    if constexpr (input_type == advance_io_type_t::graph) {
+      v = static_cast<vertex_t>(orig_idx);
+    } else {
+      v = input[orig_idx];
+    }
+    
+    vertices[local_idx] = v;
+    
+    if (gunrock::util::limits::is_valid(v)) {
+      // Use original segments - no recomputation!
+      output_starts[local_idx] = segments[orig_idx];
+      degrees[local_idx] = segments[orig_idx + 1] - segments[orig_idx];
+      graph_edge_starts[local_idx] = G.get_starting_edge(v);
+    } else {
+      degrees[local_idx] = 0;
+    }
+  } else {
+    degrees[local_idx] = 0;
+  }
+  __syncthreads();
+  
+  // Compute total work for this block
+  edge_t total_work = 0;
+  for (int i = 0; i < THREADS_PER_BLOCK; i++) {
+    total_work += degrees[i];
+  }
+  
+  // Each thread processes multiple edges
+  for (edge_t work_idx = local_idx; work_idx < total_work; work_idx += THREADS_PER_BLOCK) {
+    // Binary search to find which vertex this work belongs to
+    edge_t cumulative = 0;
+    int vertex_idx = 0;
+    for (int i = 0; i < THREADS_PER_BLOCK; i++) {
+      if (work_idx >= cumulative && work_idx < cumulative + degrees[i]) {
+        vertex_idx = i;
+        break;
+      }
+      cumulative += degrees[i];
+    }
+    
+    vertex_t v = vertices[vertex_idx];
+    if (!gunrock::util::limits::is_valid(v))
+      continue;
+    
+    // Compute edge offset within this vertex's edges
+    edge_t cumulative_before = 0;
+    for (int i = 0; i < vertex_idx; i++) {
+      cumulative_before += degrees[i];
+    }
+    edge_t edge_offset = work_idx - cumulative_before;
+    
+    // Get graph edge and output position
+    edge_t graph_e = graph_edge_starts[vertex_idx] + edge_offset;
+    edge_t output_pos = output_starts[vertex_idx] + edge_offset;
+    
+    vertex_t n = G.get_destination_vertex(graph_e);
+    weight_t w = G.get_edge_weight(graph_e);
+    
+    bool cond = op(v, n, graph_e, w);
+    
+    if constexpr (output_type != advance_io_type_t::none) {
+      output[output_pos] = cond ? n : gunrock::numeric_limits<vertex_t>::invalid();
+    }
+  }
+}
+
+/**
+ * @brief Main execution function for LRB advance operator.
+ *
+ * @tparam direction Advance direction (forward/backward)
+ * @tparam input_type Input frontier type
+ * @tparam output_type Output frontier type
+ * @tparam graph_t Graph type
+ * @tparam operator_t Operator type
+ * @tparam frontier_t Frontier type
+ * @tparam work_tiles_t Segment offsets type
+ * @param G Graph object
+ * @param op User-defined operator
+ * @param input Input frontier
+ * @param output Output frontier
+ * @param segments Segment offsets (reused for LRB)
+ * @param context CUDA context
+ */
+template <advance_direction_t direction,
+          advance_io_type_t input_type,
+          advance_io_type_t output_type,
+          typename graph_t,
+          typename operator_t,
+          typename frontier_t,
+          typename work_tiles_t>
+void execute(graph_t& G,
+             operator_t op,
+             frontier_t& input,
+             frontier_t& output,
+             work_tiles_t& segments,
+             gcuda::standard_context_t& context) {
+  using vertex_t = typename graph_t::vertex_type;
+  using edge_t = typename graph_t::edge_type;
+  
+  // Get input size
+  std::size_t input_size = (input_type == advance_io_type_t::graph)
+                               ? G.get_number_of_vertices()
+                               : input.get_number_of_elements();
+  
+  if (input_size == 0) {
+    if constexpr (output_type != advance_io_type_t::none) {
+      output.set_number_of_elements(0);
+    }
+    return;
+  }
+  
+  // Compute output size and allocate output frontier
+  std::size_t output_size = 0;
+  if constexpr (output_type != advance_io_type_t::none) {
+    output_size = compute_output_length(G, input, context,
+                                        (input_type == advance_io_type_t::graph));
+    
+    if (output_size == 0) {
+      output.set_number_of_elements(0);
+      return;
+    }
+    
+    if (output.get_capacity() < output_size)
+      output.reserve(output_size);
+    output.set_number_of_elements(output_size);
+    output.fill(gunrock::numeric_limits<vertex_t>::invalid(), context.stream());
+  }
+  
+  // Phase 1 Optimization: Use indirect indexing instead of reordering
+  // Allocate LRB data structures (reduced memory footprint)
+  thrust::device_vector<int32_t> bins(NUM_BINS);
+  thrust::device_vector<int32_t> prefix_bins(NUM_BINS + 1);
+  thrust::device_vector<int32_t> bin_membership(input_size);  // Which bin each vertex belongs to
+  thrust::device_vector<int32_t> sorted_indices(input_size);  // Indices sorted by bin
+  
+  // Compute output offsets for the original frontier (used directly, no recomputation needed)
+  std::size_t computed_output_size = compute_output_offsets(
+      G, &input, segments, context,
+      (input_type == advance_io_type_t::graph));
+  
+  // Verify output size matches
+  if constexpr (output_type != advance_io_type_t::none) {
+    if (computed_output_size != output_size) {
+      output_size = computed_output_size;
+      if (output.get_capacity() < output_size)
+        output.reserve(output_size);
+      output.set_number_of_elements(output_size);
+      output.fill(gunrock::numeric_limits<vertex_t>::invalid(), context.stream());
+    }
+  }
+  
+  // Step 1: Compute bin membership for each vertex (Phase 1 optimization)
+  int membership_blocks = (input_size + 255) / 256;
+  if (membership_blocks > 0) {
+    auto input_data = (input_type == advance_io_type_t::graph)
+                          ? nullptr
+                          : input.data();
+    
+    if (input_type == advance_io_type_t::graph) {
+      compute_bin_membership_kernel<<<membership_blocks, 256, 0, context.stream()>>>(
+          G, thrust::make_counting_iterator<vertex_t>(0),
+          bin_membership.data().get(), input_size);
+    } else {
+      compute_bin_membership_kernel<<<membership_blocks, 256, 0, context.stream()>>>(
+          G, input_data, bin_membership.data().get(), input_size);
+    }
+  }
+  
+  // Step 2: Initialize sorted_indices as [0, 1, 2, ..., input_size-1]
+  thrust::sequence(context.execution_policy(), 
+                   sorted_indices.begin(), sorted_indices.end());
+  
+  // Step 3: Sort indices by bin membership (stable sort preserves order within bins)
+  // This gives us indices grouped by bin, but we don't move the actual vertices
+  thrust::stable_sort_by_key(
+      context.execution_policy(),
+      bin_membership.begin(), bin_membership.end(),
+      sorted_indices.begin()
+  );
+  
+  // Step 4: Count bins and compute prefix sum
+  thrust::fill(context.execution_policy(), bins.begin(), bins.end(), 0);
+  
+  // Count how many vertices in each bin (after sorting)
+  int count_blocks = (input_size + 255) / 256;
+  if (count_blocks > 0) {
+    count_sorted_bins_kernel<<<count_blocks, 256, 0, context.stream()>>>(
+        bin_membership.data().get(), bins.data().get(), input_size);
+  }
+  
+  // Compute prefix sum over bins
+  bin_prefix_kernel<<<1, 1, 0, context.stream()>>>(bins.data().get(),
+                                                     prefix_bins.data().get());
+  
+  // Copy prefix bins to host to determine bin boundaries
+  thrust::host_vector<int32_t> h_prefix_bins(prefix_bins);
+  
+  // Step 5: Process bins with appropriate strategies (Phase 1 optimized)
+  // Note: Bins are indexed from 0 (largest degrees) to NUM_BINS-1 (smallest)
+  // We use sorted_indices to access vertices, and original segments for output positions
+  
+  auto input_data = (input_type == advance_io_type_t::graph)
+                        ? nullptr
+                        : input.data();
+  
+  // Process large bins (bins 0 to BIN_LARGE_START)
+  // These have degrees from 2^(31-BIN_LARGE_START) to 2^31
+  // For now, use medium bin strategy (Phase 3 will add CUB)
+  
+  // Process medium bins (bins BIN_LARGE_START to BIN_MEDIUM_START)
+  for (int bin = 0; bin <= BIN_MEDIUM_START; bin++) {
+    int start = h_prefix_bins[bin];
+    int end = h_prefix_bins[bin + 1];
+    
+    if (end <= start)
+      continue;
+    
+    int num_vertices = end - start;
+    int blocks = (num_vertices + 255) / 256;
+    
+    if (input_type == advance_io_type_t::graph) {
+      process_medium_bins_kernel<256, output_type, advance_io_type_t::graph>
+          <<<blocks, 256, 0, context.stream()>>>(
+              G, op, thrust::make_counting_iterator<vertex_t>(0),
+              sorted_indices.data().get(), output.data(),
+              segments.data().get(), start, end);
+    } else {
+      process_medium_bins_kernel<256, output_type, advance_io_type_t::vertices>
+          <<<blocks, 256, 0, context.stream()>>>(
+              G, op, input_data, sorted_indices.data().get(),
+              output.data(), segments.data().get(), start, end);
+    }
+  }
+  
+  // Process small bins (bins BIN_MEDIUM_START+1 to NUM_BINS-1)
+  for (int bin = BIN_MEDIUM_START + 1; bin < NUM_BINS; bin++) {
+    int start = h_prefix_bins[bin];
+    int end = h_prefix_bins[bin + 1];
+    
+    if (end <= start)
+      continue;
+    
+    int num_vertices = end - start;
+    int blocks = (num_vertices + 255) / 256;
+    
+    if (input_type == advance_io_type_t::graph) {
+      process_small_bins_kernel<output_type, advance_io_type_t::graph>
+          <<<blocks, 256, 0, context.stream()>>>(
+              G, op, thrust::make_counting_iterator<vertex_t>(0),
+              sorted_indices.data().get(), output.data(),
+              segments.data().get(), start, end);
+    } else {
+      process_small_bins_kernel<output_type, advance_io_type_t::vertices>
+          <<<blocks, 256, 0, context.stream()>>>(
+              G, op, input_data, sorted_indices.data().get(),
+              output.data(), segments.data().get(), start, end);
+    }
+  }
+  
+  context.synchronize();
+}
+
+}  // namespace lrb
+}  // namespace advance
+}  // namespace operators
+}  // namespace gunrock

--- a/include/gunrock/framework/operators/advance/lrb.hxx
+++ b/include/gunrock/framework/operators/advance/lrb.hxx
@@ -666,8 +666,10 @@ void execute(graph_t& G,
   // Synchronize and destroy all streams (if created)
   if (use_streams) {
     for (int i = 0; i < NUM_STREAMS; i++) {
-      hipStreamSynchronize(streams[i]);
-      hipStreamDestroy(streams[i]);
+      auto sync_err = hipStreamSynchronize(streams[i]);
+      (void)sync_err;  // Suppress nodiscard warning
+      auto destroy_err = hipStreamDestroy(streams[i]);
+      (void)destroy_err;  // Suppress nodiscard warning
     }
   }
   

--- a/include/gunrock/framework/operators/configs.hxx
+++ b/include/gunrock/framework/operators/configs.hxx
@@ -54,8 +54,8 @@ enum load_balance_t {
   warp_mapped,    ///< (wip) Equal # of elements per warp
   block_mapped,   ///< Equal # of elements per block
   lrb,            ///< Logarithmic Radix Binning (Fox et al., HPEC 2019)
-  merge_path,     ///< Merrill & Garland (SpMV):: DEPRECATED (use merge_path_v2)
-  merge_path_v2,  ///< Merrill & Garland (SpMV):: CUSTOM
+  merge_path,     ///< Merrill & Garland (SpMV)
+  merge_path_v2,  ///< Merrill & Garland (SpMV):: Not Supported
   work_stealing,  ///< (wip) <cite>
 };
 

--- a/include/gunrock/framework/operators/configs.hxx
+++ b/include/gunrock/framework/operators/configs.hxx
@@ -53,7 +53,7 @@ enum load_balance_t {
   thread_mapped,  ///< 1 element per thread
   warp_mapped,    ///< (wip) Equal # of elements per warp
   block_mapped,   ///< Equal # of elements per block
-  bucketing,      ///< (wip) Davidson et al. (SSSP)
+  lrb,            ///< Logarithmic Radix Binning (Fox et al., HPEC 2019)
   merge_path,     ///< Merrill & Garland (SpMV):: DEPRECATED (use merge_path_v2)
   merge_path_v2,  ///< Merrill & Garland (SpMV):: CUSTOM
   work_stealing,  ///< (wip) <cite>

--- a/include/gunrock/io/parameters.hxx
+++ b/include/gunrock/io/parameters.hxx
@@ -247,7 +247,7 @@ operators::load_balance_t parse_load_balance(std::string str) {
   if (str == "thread_mapped") return operators::load_balance_t::thread_mapped;
   if (str == "warp_mapped") return operators::load_balance_t::warp_mapped;
   if (str == "block_mapped") return operators::load_balance_t::block_mapped;
-  if (str == "bucketing") return operators::load_balance_t::bucketing;
+  if (str == "lrb") return operators::load_balance_t::lrb;
   if (str == "merge_path") return operators::load_balance_t::merge_path;
   if (str == "merge_path_v2") return operators::load_balance_t::merge_path_v2;
   if (str == "work_stealing") return operators::load_balance_t::work_stealing;

--- a/python/src/gunrock/__init__.py
+++ b/python/src/gunrock/__init__.py
@@ -8,7 +8,7 @@ High-performance graph algorithms on GPUs using ROCm/HIP.
 """
 
 try:
-    # Import the compiled module directly
+    # Import the compiled extension module
     from . import gunrock as _gunrock
     
     # Re-export everything from the compiled module
@@ -17,6 +17,30 @@ try:
         memory_space_t,
         multi_context_t,
         options_t,
+        
+        # Operator enums (types)
+        load_balance_t,
+        filter_algorithm_t,
+        uniquify_algorithm_t,
+        
+        # Load balance enum values (exported via .export_values())
+        thread_mapped,
+        warp_mapped,
+        block_mapped,
+        lrb,
+        merge_path,
+        merge_path_v2,
+        work_stealing,
+        
+        # Filter algorithm enum values
+        remove,
+        predicated,
+        compact,
+        bypass,
+        
+        # Uniquify algorithm enum values
+        unique,
+        unique_copy,
         
         # Graph structures
         graph_properties_t,
@@ -113,6 +137,30 @@ __all__ = [
     "memory_space_t",
     "multi_context_t",
     "options_t",
+    
+    # Operator enums (types)
+    "load_balance_t",
+    "filter_algorithm_t",
+    "uniquify_algorithm_t",
+    
+    # Load balance enum values
+    "thread_mapped",
+    "warp_mapped",
+    "block_mapped",
+    "lrb",
+    "merge_path",
+    "merge_path_v2",
+    "work_stealing",
+    
+    # Filter algorithm enum values
+    "remove",
+    "predicated",
+    "compact",
+    "bypass",
+    
+    # Uniquify algorithm enum values
+    "unique",
+    "unique_copy",
     
     # Graph structures
     "graph_properties_t",

--- a/python/src/gunrock/bindings.cu
+++ b/python/src/gunrock/bindings.cu
@@ -17,6 +17,7 @@
 
 // Gunrock headers
 #include <gunrock/algorithms/algorithms.hxx>
+#include <gunrock/framework/operators/configs.hxx>
 #include <gunrock/algorithms/bfs.hxx>
 #include <gunrock/algorithms/sssp.hxx>
 #include <gunrock/algorithms/bc.hxx>
@@ -147,11 +148,39 @@ NB_MODULE(gunrock, m) {
       ctx.get_context(0)->synchronize();
     }, "Synchronize GPU operations");
 
+  // Load balance enum
+  nb::enum_<operators::load_balance_t>(m, "load_balance_t")
+    .value("thread_mapped", operators::load_balance_t::thread_mapped)
+    .value("warp_mapped", operators::load_balance_t::warp_mapped)
+    .value("block_mapped", operators::load_balance_t::block_mapped)
+    .value("lrb", operators::load_balance_t::lrb)
+    .value("merge_path", operators::load_balance_t::merge_path)
+    .value("merge_path_v2", operators::load_balance_t::merge_path_v2)
+    .value("work_stealing", operators::load_balance_t::work_stealing)
+    .export_values();
+
+  // Filter algorithm enum
+  nb::enum_<operators::filter_algorithm_t>(m, "filter_algorithm_t")
+    .value("remove", operators::filter_algorithm_t::remove)
+    .value("predicated", operators::filter_algorithm_t::predicated)
+    .value("compact", operators::filter_algorithm_t::compact)
+    .value("bypass", operators::filter_algorithm_t::bypass)
+    .export_values();
+
+  // Uniquify algorithm enum
+  nb::enum_<operators::uniquify_algorithm_t>(m, "uniquify_algorithm_t")
+    .value("unique", operators::uniquify_algorithm_t::unique)
+    .value("unique_copy", operators::uniquify_algorithm_t::unique_copy)
+    .export_values();
+
   // Options
   nb::class_<options_t>(m, "options_t")
     .def(nb::init<>())
     .def_rw("advance_load_balance", &options_t::advance_load_balance)
+    .def_rw("filter_algorithm", &options_t::filter_algorithm)
+    .def_rw("enable_filter", &options_t::enable_filter)
     .def_rw("enable_uniquify", &options_t::enable_uniquify)
+    .def_rw("uniquify_algorithm", &options_t::uniquify_algorithm)
     .def_rw("best_effort_uniquify", &options_t::best_effort_uniquify)
     .def_rw("uniquify_percent", &options_t::uniquify_percent);
 


### PR DESCRIPTION
## ROCm 7.1 (MI300X)

> [!WARNING]
> Unoptimized.

# BFS Performance (GPU Elapsed Time in ms)

| Dataset | Vertices | Edges | LRB | block_mapped | merge_path |
|---------|----------|-------|-----|--------------|------------|
| chesapeake | 39 | 170 | 1.75 | 0.18 | 0.24 |
| delaunay_n13 | 8,192 | 24,528 | 11.37 | 2.36 | 2.76 |
| delaunay_n24 | 16,777,216 | 50,331,601 | 1334.95 | 114.55 | 153.44 |
| soc-LiveJournal1 | 4,847,571 | 68,993,773 | 720.67 | 8.29 | 7.09 |
| hollywood-2009 | 1,139,905 | 57,515,616 | 1286.32 | 12.67 | 9.67 |
| arabic-2005 | 22,744,080 | 639,999,458 | 0.33 | 0.11 | 0.11 |
| road_usa | 23,947,347 | 58,333,344 | 2151.86 | 499.57 | 555.60 |

## SSSP Performance (GPU Elapsed Time in ms)

| Dataset | Vertices | Edges | LRB | block_mapped | merge_path |
|---------|----------|-------|-----|--------------|------------|
| chesapeake | 39 | 170 | 0.99 | 0.22 | 0.28 |
| delaunay_n13 | 8,192 | 24,528 | 11.99 | 2.95 | 3.78 |
| soc-LiveJournal1 | 4,847,571 | 68,993,773 | 731.82 | 8.15 | 9.34 |
| hollywood-2009 | 1,139,905 | 57,515,616 | 1283.65 | 15.93 | 20.43 |

**References:**
- https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8916333
- https://github.com/ogreen/segmented-sort/blob/main/lrb_sort.cuh
- https://github.com/NVIDIA/cub/pull/357

This pull request updates the available load balancing strategies in the advance operator framework, replacing the deprecated `bucketing` method with the newer `lrb` (Logarithmic Radix Binning) approach, and integrating support for `lrb` throughout the codebase. The changes ensure that `lrb` is recognized as a valid load balancing option and can be selected and executed like other strategies.

### Load balancing strategy updates

* Replaced the deprecated `bucketing` load balancing strategy with `lrb` (Logarithmic Radix Binning) in the `load_balance_t` enum in `configs.hxx`, updating documentation comments to reflect the change.
* Updated `advance.hxx` to remove the inclusion of `bucketing.hxx` and instead include `lrb.hxx`, ensuring the correct implementation is used.
* Added support for executing the `lrb` strategy in both the main and runtime `execute` functions in `advance.hxx`, allowing `lrb` to be selected and run like other load balancing methods. [[1]](diffhunk://#diff-b7b1ead43d1f0ba92f2f75afae5027a18e65a867e06f9ade4bdebcc323a28303R125-R127) [[2]](diffhunk://#diff-b7b1ead43d1f0ba92f2f75afae5027a18e65a867e06f9ade4bdebcc323a28303R275-R278)

### Configuration and parameter parsing

* Modified the load balancing string parser in `parameters.hxx` to recognize `"lrb"` as a valid input, mapping it to the new strategy in the codebase.